### PR TITLE
392 nested geons

### DIFF
--- a/adam/visualization/__init__.py
+++ b/adam/visualization/__init__.py
@@ -4,7 +4,9 @@
         make_scenes.py:
             Converts perceptual representations of scenes into 3d rendered scenes.
 
-            Requires a parameters file to be run.
+            Currently this visualizes only a hardcoded set of scenes
+
+            Requires a parameters file to be run. See parameters/make_scenes.params for an example
 
     Other modules:
         panda3d_interface.py:

--- a/adam/visualization/__init__.py
+++ b/adam/visualization/__init__.py
@@ -1,0 +1,21 @@
+""" Visualization module: Code for producing more human-friendly representations of scenes from curricula.
+
+    Main executable:
+        make_scenes.py:
+            Converts perceptual representations of scenes into 3d rendered scenes.
+
+            Requires a parameters file to be run.
+
+    Other modules:
+        panda3d_interface.py:
+            Interface for the Panda3D rendering engine. Responsible for creating, destroying, positioning, coloring, etc
+            objects that are arranged in 3D space to represent perceptions of scenes.
+
+        positioning.py:
+            Module defining a Stochastic Gradient Descent model for arranging objects in a scene. Responsible for
+            translating relative layout requirements into a concrete layout.
+
+        utils.py:
+            Miscellaneous type definitions used by multiple visualization modules.
+
+"""

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -72,7 +72,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    random.seed(2015)
+    random.seed(468)
 
     # go through curriculum scenes and output geometry types
     print("scene generation test")

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -3,13 +3,15 @@
    operating and when other code (gathering and processing scene information)
    is executing in a serial manner.
    """
-from typing import Iterable, List, Tuple, Union, DefaultDict
+from typing import Iterable, List, Tuple, Union, DefaultDict, Optional
 
 import random
 from collections import defaultdict
 
 from adam.curriculum.phase1_curriculum import build_gaila_phase_1_curriculum
+import attr
 from attr import attrs
+from immutablecollections import ImmutableSet, immutableset
 
 from adam.language.dependency import LinearizedDependencyTree
 
@@ -23,12 +25,17 @@ from adam.perception.developmental_primitive_perception import (
     HasColor,
     HasBinaryProperty,
     ObjectPerception,
+    Relation
 )
 from adam.ontology import OntologyNode
 
 from adam.visualization.panda3d_interface import SituationVisualizer
 from adam.visualization.utils import Shape
 
+@attrs(slots=True)
+class SceneNode:
+    elt: ObjectPerception = attr.ib()
+    children: List["SceneNode"] = attr.ib(factory=list)
 
 def main() -> None:
     random.seed(2015)
@@ -87,11 +94,14 @@ class SceneCreator:
             ) in instance_group.instances():  # each instance a scene
                 # scene_objects = []
                 property_map: DefaultDict[
-                    ObjectPerception, List[Union[RgbColorPerception, OntologyNode]]
+                    ObjectPerception, List[Optional[Union[RgbColorPerception, OntologyNode]]]
                 ] = defaultdict(list)
                 # we only care about the perception at the moment
 
+
+
                 for frame in perception.frames:  # DevelopmentalPrimitivePerceptionFrame
+                    # actions will have multiple frames - these will have to be rendered differently
                     for prop in frame.property_assertions:
                         if isinstance(prop, HasColor):
                             # append RgbColorPerception
@@ -101,7 +111,21 @@ class SceneCreator:
                             property_map[prop.perceived_object].append(
                                 prop.binary_property
                             )
-                print(property_map)
+
+                    print("\n\n")
+                    print(frame.relations[0])
+                    print(frame.relations[0].relation_type)
+                    print(frame.relations[0].first_slot)
+                    print(type(frame.relations[0].second_slot))
+                    print("\n\n")
+                    SceneCreator.nest_objects(frame.relations)
+                    print("\n\n")
+
+                    # in the event that an object has no properties, we add it anyway
+                    # in case it has a geon that can be rendered
+                    for obj in frame.perceived_objects:
+                        if obj not in property_map:
+                            property_map[obj].append(None)
 
                 yield property_map
 
@@ -128,6 +152,61 @@ class SceneCreator:
         else:
             raise ValueError("Unknown Geon composition")
 
+
+
+    @staticmethod
+    def nest_objects(relations: ImmutableSet[Relation["ObjectPerception"]]) -> None:
+        """Given a set of Relations, return some kind of mapping of
+           the objects that the relations pertain to according to the partOf() relations that they have.
+
+           This could be an ImmutableSet(immutabledict {root_obj : [leaf_objects]}
+
+           could be regular data structures at first and converted to immutable ones after
+
+        """
+        # would we need a placeholder root object to be removed before returning?
+        d = defaultdict(list)
+        for relation in relations:
+            if relation.relation_type.handle == "partOf": # should be a better way to check
+                d[relation.second_slot].append(relation.first_slot)
+
+        # so now we have everything nested a single level
+        print(d)
+
+        most_to_least = sorted((k for k in d), key=lambda k: len(d[k]), reverse=True)
+        print(most_to_least)
+
+        scene_graph = []
+        for key in most_to_least:
+            print(f"assigning key {key}")
+            print(f"current graph: {scene_graph}")
+            search_node = None
+            search_candidates = [node for node in scene_graph]
+            print(f"search candidates: {search_candidates}")
+            while len(search_candidates) > 0:
+                new_prospects = []
+                for candidate in search_candidates:
+                    print(f"candidate: {candidate}")
+                    for child in candidate.children:
+                        print(f"child: {child}")
+                        if child.elt == key:
+                            search_node = child
+                            break
+                        else:
+                            new_prospects.append(child)
+                search_candidates = new_prospects
+
+            if search_node is None:
+                search_node = SceneNode(key)
+                scene_graph.append(search_node)
+            print(f"found node is {search_node}")
+            # find node with key
+            for nested in d[key]:
+                search_node.children.append(SceneNode(nested))
+
+        return scene_graph
+
+
     @staticmethod
     def random_position() -> Tuple[float, float, float]:
         """Placeholder implementation for turning the relative position
@@ -135,7 +214,7 @@ class SceneCreator:
         x: float = random.uniform(-7.0, 7.0)
         y: float = random.uniform(-5.0, 5.0)
         z: float = random.uniform(0.0, 4.0)
-        return (x, y, z)
+        return x, y, z
 
 
 if __name__ == "__main__":

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -56,6 +56,7 @@ USAGE_MESSAGE = """make_scenes.py param_file
                 \twhere param_file has the following parameters:
                 \t\titerations: int: total number of iterations to run positioning model over
                 \t\tsteps_before_vis: int: number of iterations of positioning model before scene is re-rendered
+                \t\tseed: int: random seed for picking initial object positions
                 """
 
 
@@ -77,7 +78,7 @@ def main(params: Parameters) -> None:
     num_iterations = params.integer("iterations")
     steps_before_vis = params.integer("steps_before_vis")
 
-    random.seed(468)
+    random.seed(params.integer("seed"))
 
     # go through curriculum scenes and output geometry types
     print("scene generation test")

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -3,7 +3,8 @@
    operating and when other code (gathering and processing scene information)
    is executing in a serial manner.
    """
-from typing import Iterable, List, Tuple, Union, DefaultDict, Optional
+from typing import Iterable, List, Tuple, Union, DefaultDict, Optional, Callable
+from functools import partial
 
 import random
 from collections import defaultdict
@@ -11,7 +12,7 @@ from collections import defaultdict
 from adam.curriculum.phase1_curriculum import build_gaila_phase_1_curriculum
 import attr
 from attr import attrs
-from immutablecollections import ImmutableSet, immutableset
+from immutablecollections import ImmutableSet
 
 from adam.language.dependency import LinearizedDependencyTree
 
@@ -25,51 +26,60 @@ from adam.perception.developmental_primitive_perception import (
     HasColor,
     HasBinaryProperty,
     ObjectPerception,
-    Relation
+    Relation,
 )
 from adam.ontology import OntologyNode
 
 from adam.visualization.panda3d_interface import SituationVisualizer
 from adam.visualization.utils import Shape
 
+
 @attrs(slots=True)
 class SceneNode:
     elt: ObjectPerception = attr.ib()
     children: List["SceneNode"] = attr.ib(factory=list)
 
+
 def main() -> None:
     random.seed(2015)
 
-    # go through curriculum scenes (fed in from where?) and output geometry types
+    # go through curriculum scenes and output geometry types
     print("scene generation test")
     viz = SituationVisualizer()
-    for i, scene in enumerate(
+    for i, (property_map, obj_graph) in enumerate(
         SceneCreator.create_scenes(build_gaila_phase_1_curriculum())
     ):
         print(f"SCENE {i}")
-        for obj, properties in scene.items():
-            print(f"Object: {obj}")
-            # only interested in rendering geons
-            # TODO***: allow for Irregular geons to be rendered
-            if (
-                obj.geon is None
-                or SceneCreator.cross_section_to_geo(obj.geon.cross_section)
-                == Shape.IRREGULAR
-            ):
-                continue
-            color = None
-            for prop in properties:
-                if isinstance(prop, RgbColorPerception):
-                    color = prop
-            viz.add_model(
-                SceneCreator.cross_section_to_geo(obj.geon.cross_section),
-                SceneCreator.random_position(),
-                color,
-            )
+        # bind visualizer and properties to render function:
+        bound_render_obj = partial(
+            render_obj, viz, property_map
+        )  # bind renderer to function
+        # render each object in graph
+        SceneCreator.graph_for_each(obj_graph, bound_render_obj)
         viz.run_for_seconds(2.25)
         input("Press ENTER to continue")
         viz.clear_scene()
         viz.run_for_seconds(0.25)
+
+
+def render_obj(
+    renderer: SituationVisualizer,
+    properties: DefaultDict[
+        ObjectPerception, List[Optional[Union[RgbColorPerception, OntologyNode]]]
+    ],
+    obj: ObjectPerception,
+) -> None:
+    if obj.geon is None:
+        return
+    shape = SceneCreator.cross_section_to_geo(obj.geon.cross_section)
+    # TODO***: allow for Irregular geons to be rendered
+    if shape == Shape.IRREGULAR:
+        return
+    color = None
+    for prop in properties[obj]:
+        if isinstance(prop, RgbColorPerception):
+            color = prop
+    renderer.add_model(shape, SceneCreator.random_position(), color)
 
 
 @attrs(frozen=True, slots=True)
@@ -94,11 +104,10 @@ class SceneCreator:
             ) in instance_group.instances():  # each instance a scene
                 # scene_objects = []
                 property_map: DefaultDict[
-                    ObjectPerception, List[Optional[Union[RgbColorPerception, OntologyNode]]]
+                    ObjectPerception,
+                    List[Optional[Union[RgbColorPerception, OntologyNode]]],
                 ] = defaultdict(list)
                 # we only care about the perception at the moment
-
-
 
                 for frame in perception.frames:  # DevelopmentalPrimitivePerceptionFrame
                     # actions will have multiple frames - these will have to be rendered differently
@@ -112,14 +121,9 @@ class SceneCreator:
                                 prop.binary_property
                             )
 
-                    print("\n\n")
-                    print(frame.relations[0])
-                    print(frame.relations[0].relation_type)
-                    print(frame.relations[0].first_slot)
-                    print(type(frame.relations[0].second_slot))
-                    print("\n\n")
-                    SceneCreator.nest_objects(frame.relations)
-                    print("\n\n")
+                    nested_objects = SceneCreator._nest_objects(
+                        frame.perceived_objects, frame.relations
+                    )
 
                     # in the event that an object has no properties, we add it anyway
                     # in case it has a geon that can be rendered
@@ -127,7 +131,7 @@ class SceneCreator:
                         if obj not in property_map:
                             property_map[obj].append(None)
 
-                yield property_map
+                yield property_map, nested_objects
 
     @staticmethod
     def cross_section_to_geo(cs: CrossSection) -> Shape:
@@ -152,43 +156,44 @@ class SceneCreator:
         else:
             raise ValueError("Unknown Geon composition")
 
-
-
     @staticmethod
-    def nest_objects(relations: ImmutableSet[Relation["ObjectPerception"]]) -> None:
-        """Given a set of Relations, return some kind of mapping of
-           the objects that the relations pertain to according to the partOf() relations that they have.
-
-           This could be an ImmutableSet(immutabledict {root_obj : [leaf_objects]}
-
-           could be regular data structures at first and converted to immutable ones after
-
+    def _nest_objects(
+        perceived_objects: ImmutableSet[ObjectPerception],
+        relations: ImmutableSet[Relation["ObjectPerception"]],
+    ) -> List[SceneNode]:
         """
-        # would we need a placeholder root object to be removed before returning?
-        d = defaultdict(list)
+        Given a set of objects and corresponding relations, return a pseudo-tree structure
+        that has all objects with a partOf relationship between one another nested
+        accordingly, with all singular objects residing at the top level.
+        (If it was really a tree, there would only be one root element instead of a list).
+        """
+        d: DefaultDict[ObjectPerception, List["ObjectPerception"]] = defaultdict(list)
         for relation in relations:
-            if relation.relation_type.handle == "partOf": # should be a better way to check
+            if relation.relation_type.handle == "partOf" and isinstance(
+                relation.second_slot, ObjectPerception
+            ):  # should be a better way to check
                 d[relation.second_slot].append(relation.first_slot)
 
+        # add all additional objects not covered with partOf relations
+        for obj in perceived_objects:
+            if obj not in d:
+                # just create default empty list by accessing dict at key
+                d[obj]  # pylint: disable=pointless-statement
+
         # so now we have everything nested a single level
-        print(d)
 
+        # probably not strictly necessary, but the thing with the most
+        # references in partOf is probably higher up in the tree
         most_to_least = sorted((k for k in d), key=lambda k: len(d[k]), reverse=True)
-        print(most_to_least)
-
-        scene_graph = []
+        # scene graph is a nested structure where multiple items can be at the top level
+        scene_graph: List[SceneNode] = []
         for key in most_to_least:
-            print(f"assigning key {key}")
-            print(f"current graph: {scene_graph}")
             search_node = None
             search_candidates = [node for node in scene_graph]
-            print(f"search candidates: {search_candidates}")
-            while len(search_candidates) > 0:
+            while search_candidates:
                 new_prospects = []
                 for candidate in search_candidates:
-                    print(f"candidate: {candidate}")
                     for child in candidate.children:
-                        print(f"child: {child}")
                         if child.elt == key:
                             search_node = child
                             break
@@ -199,13 +204,26 @@ class SceneCreator:
             if search_node is None:
                 search_node = SceneNode(key)
                 scene_graph.append(search_node)
-            print(f"found node is {search_node}")
             # find node with key
             for nested in d[key]:
                 search_node.children.append(SceneNode(nested))
 
         return scene_graph
 
+    @staticmethod
+    def graph_for_each(
+        graph: List[SceneNode], fn: Callable[["ObjectPerception"], None]
+    ) -> None:
+        """Apply some function to each node of the scene graph"""
+        nodes = graph
+        while nodes:
+            recurse: List[SceneNode] = []
+            for node in nodes:
+                if not node.children:
+                    fn(node.elt)
+                else:
+                    recurse += node.children
+            nodes = recurse
 
     @staticmethod
     def random_position() -> Tuple[float, float, float]:

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -12,7 +12,6 @@ from typing import (
     Optional,
     Callable,
     Any,
-    Generator,
     Dict,
 )
 from functools import partial
@@ -75,8 +74,8 @@ class SceneNode:
 
 
 def main(params: Parameters) -> None:
-    num_iterations = params.integer("iterations")
-    steps_before_vis = params.integer("steps_before_vis")
+    num_iterations = params.positive_integer("iterations")
+    steps_before_vis = params.positive_integer("steps_before_vis")
 
     random.seed(params.integer("seed"))
 
@@ -417,7 +416,7 @@ def _solve_top_level_positions(
     parent_positions: Dict[str, Tuple[float, float, float]],
     iterations: int = 200,
     yield_steps: Optional[int] = None,
-) -> Generator[PositionsMap, None, PositionsMap]:
+) -> Iterable[PositionsMap]:
     """
         Solves for positions of top-level objects.
     Args:

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -129,7 +129,9 @@ class SituationVisualizer(ShowBase):
         # top level:
         if parent is None:
             if name in self.geo_nodes:
-                raise RuntimeError("Model names need to be unique")
+                raise RuntimeError(
+                    f"Error using name {name}: Model names need to be unique"
+                )
             self.geo_nodes[new_model.name] = new_model
             new_model.reparentTo(self.render)
         # nested
@@ -150,7 +152,9 @@ class SituationVisualizer(ShowBase):
         if parent is None:
             new_node.reparentTo(self.render)
             if name in self.geo_nodes:
-                raise RuntimeError("Model names need to be unique")
+                raise RuntimeError(
+                    f"Error using name {name}: Model names need to be unique"
+                )
             self.geo_nodes[new_node.name] = new_node
         else:
             new_node.reparentTo(parent)

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -59,7 +59,7 @@ class SituationVisualizer(ShowBase):
 
         self.ground_plane = self._load_model("ground.egg")
         self.ground_plane.reparentTo(self.render)
-        self.ground_plane.setPos(0, 0, -1)
+        self.ground_plane.setPos(0, 0, -2)
         m = Material()
         m.setDiffuse((255, 255, 255, 255))
         # the "1" argument to setMaterial is crucial to have it override
@@ -134,10 +134,10 @@ class SituationVisualizer(ShowBase):
         new_node = NodePath(name)
         if parent is None:
             new_node.reparentTo(self.render)
+            self.geo_nodes.append(new_node)
         else:
             new_node.reparentTo(parent)
         new_node.setPos(*pos)
-        self.geo_nodes.append(new_node)
         return new_node
 
     def clear_scene(self) -> None:

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -9,7 +9,6 @@
    the capability to display objects with various properties
    supplied from elsewhere.
    """
-from math import pi, sin, cos
 
 from typing import Tuple, Optional, Dict
 import sys
@@ -108,10 +107,10 @@ class SituationVisualizer(ShowBase):
         Adds a piece of primitive geometry to the scene.
         Args:
             model_type: The shape used to represent the model
-            name: unique name given to this object
-            position: The position (x, y, z), (z is up) to place the new model
-            color: RBG color for this model
-            parent: Reference to a previously placed model (the type returned from this function). If supplied,
+            *name*: unique name given to this object
+            *position*: The position (x, y, z), (z is up) to place the new model
+            *color*: RBG color for this model
+            *parent*: Reference to a previously placed model (the type returned from this function). If supplied,
                     the new model will be *nested* under this parent model, making its position, orientation, scale
                     relative to the parent model.
 
@@ -176,29 +175,6 @@ class SituationVisualizer(ShowBase):
                 position.data[0], position.data[1], position.data[2]
             )
 
-    def test_scene_init(self) -> None:
-        """Initialize a test scene with sample geometry, including a camera rotate task"""
-        cylinder = self._load_model("cylinder.egg")
-        self.geo_nodes["cylinder"] = cylinder
-        # Reparent the model to render.
-        cylinder.reparentTo(self.render)
-
-        cube = self._load_model("cube.egg")
-        self.geo_nodes["cube0"] = cube
-        cube.reparentTo(self.render)
-        cube.setPos(0, 0, 5)
-        cube.setColor((1.0, 0.0, 0.0, 1.0))
-
-        cube2 = self._load_model("cube.egg")
-        self.geo_nodes["cube2"] = cube2
-        cube2.reparentTo(self.render)
-        cube2.setPos(5, 0, 1)
-        cube2.setScale(1.25, 1.25, 1.25)
-        cube2.setColor((0, 1, 0, 0.5))
-
-        # Add the spinCameraTask procedure to the task manager.
-        self.taskMgr.add(self._spin_camera_task, "SpinCameraTask", priority=-100)
-
     def run_for_seconds(self, seconds: float) -> None:
         """Executes main rendering loop for given seconds. This needs to be a
            healthy fraction of a second to see changes reflected in the scene."""
@@ -208,14 +184,6 @@ class SituationVisualizer(ShowBase):
 
     def print_scene_graph(self) -> None:
         print(self.render.ls())
-
-    # Define a procedure to move the camera.
-    def _spin_camera_task(self, task):
-        angle_degrees = task.time * 6.0
-        angle_radians = angle_degrees * (pi / 180.0)
-        self.camera.setPos(25 * sin(angle_radians), -25.0 * cos(angle_radians), 4)
-        self.camera.setHpr(angle_degrees, 0, 0)
-        return Task.cont
 
     def _camera_location_task(self, task):  # pylint: disable=unused-argument
         pos = self.camera.getPos()

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -214,4 +214,4 @@ class SituationVisualizer(ShowBase):
         return self.loader.loadModel(working_dir + "/adam/visualization/models/" + name)
 
 
-# for testing purposes
+

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -11,7 +11,7 @@
    """
 from math import pi, sin, cos
 
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 import sys
 import os
 
@@ -102,9 +102,11 @@ class SituationVisualizer(ShowBase):
         model_type: Shape,
         pos: Tuple[float, float, float],
         col: RgbColorPerception = None,
-    ) -> None:
+        parent: Optional[NodePath] = None,
+    ) -> NodePath:
         """Adds a piece of primitive geometry to the scene.
         Will need to be expanded to account for orientation, color, position, etc"""
+        print(f"adding: {model_type}")
         if col is None:
             col = RgbColorPerception(50, 50, 50)
         try:
@@ -112,10 +114,26 @@ class SituationVisualizer(ShowBase):
         except KeyError:
             print(f"No geometry found for {model_type}")
             raise
+        # top level:
         self.geo_nodes.append(new_model)
-        new_model.reparentTo(self.render)
+        if parent is None:
+            new_model.reparentTo(self.render)
+        # nested
+        else:
+            new_model.reparentTo(parent)
         new_model.setPos(pos[0], pos[1], pos[2])
         new_model.setColor((col.red / 255, col.green / 255, col.blue / 255, 1.0))
+        return new_model
+
+    def add_dummy_node(self, name: str, parent: Optional[NodePath] = None) -> NodePath:
+        print(f"\nAdding Dummy node: {name}")
+        new_node = NodePath(name)
+        if parent is None:
+            new_node.reparentTo(self.render)
+        else:
+            new_node.reparentTo(parent)
+        self.geo_nodes.append(new_node)
+        return new_node
 
     def clear_scene(self) -> None:
         """Clears out all added objects (other than ground plane, camera, lights)"""
@@ -152,6 +170,9 @@ class SituationVisualizer(ShowBase):
         start = int(time.time())
         while time.time() - start < seconds:
             self.taskMgr.step()
+
+    def print_scene_graph(self) -> None:
+        print(self.render.ls())
 
     # Define a procedure to move the camera.
     def _spin_camera_task(self, task):

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -212,6 +212,3 @@ class SituationVisualizer(ShowBase):
     def _load_model(self, name: str):
         working_dir = os.path.abspath((sys.path[0]))
         return self.loader.loadModel(working_dir + "/adam/visualization/models/" + name)
-
-
-

--- a/adam/visualization/positioning.py
+++ b/adam/visualization/positioning.py
@@ -4,7 +4,7 @@ that can position multiple bounding boxes s/t they do not overlap
 (in addition to other constraints).
 """
 from itertools import combinations
-from typing import Mapping, AbstractSet, Tuple, Optional, List
+from typing import Mapping, AbstractSet, Tuple, Optional, List, Generator
 from attr import attrs, attrib
 
 import numpy as np
@@ -75,9 +75,9 @@ def main() -> None:
 
 def run_model(
     objs: List[AdamObject], num_iterations: int = 200, yield_steps: Optional[int] = None
-) -> List[torch.Tensor]:
+) -> Generator[List[torch.Tensor], None, List[torch.Tensor]]:
     """
-    Construct a positioning model given a list of objects to position, return their final position values
+    Construct a positioning model given a list of objects to position, return their position values.
     Args:
         objs: list of AdamObjects requested to be positioned
         num_iterations: total number of SGD iterations.
@@ -132,7 +132,7 @@ class AxisAlignedBoundingBox:
     corners at (-1, -1, -1) and (1, 1, 1), giving the box a volume of 2(^3)
     """
 
-    center: torch.Tensor = attrib()  # tensor shape: (3,)
+    center: Parameter = attrib()  # tensor shape: (3,)
     scale: torch.Tensor = attrib()  # tensor shape: (3, 3) - diagonal matrix
     # rotation: torch.Tensor = attrib()
 
@@ -150,7 +150,11 @@ class AxisAlignedBoundingBox:
             torch.gather(
                 corners,
                 1,
-                torch.repeat_interleave(torch.tensor([[2]]), torch.tensor([8]), dim=0),
+                torch.repeat_interleave(
+                    torch.tensor([[2]]),  # pylint: disable=not-callable
+                    torch.tensor([8]),  # pylint: disable=not-callable
+                    dim=0,
+                ),
             )
         )
         return min_corner_z - ORIGIN[2]

--- a/adam/visualization/positioning.py
+++ b/adam/visualization/positioning.py
@@ -33,46 +33,6 @@ class AdamObject:
     initial_position: Optional[Tuple[float, float, float]]
 
 
-def main() -> None:
-    ball = AdamObject(name="ball", initial_position=None)
-    box = AdamObject(name="box", initial_position=None)
-
-    cardboard_box = AdamObject(name="cardboardBox", initial_position=None)
-    aardvark = AdamObject(name="aardvark", initial_position=None)
-    flamingo = AdamObject(name="flamingo", initial_position=None)
-
-    positioning_model = AdamObjectPositioningModel.for_objects_random_positions(
-        immutableset([ball, box, cardboard_box, aardvark, flamingo])
-    )
-    # we will start with an aggressive learning rate
-    optimizer = optim.SGD(positioning_model.parameters(), lr=1.0)
-    # but will decrease it whenever the loss plateaus
-    learning_rate_schedule = ReduceLROnPlateau(
-        optimizer,
-        "min",
-        # decrease the rate if the loss hasn't improved in
-        # 3 epochs
-        patience=3,
-    )
-
-    iterations = 100
-    for iteration in range(iterations):
-        print(f"====== Iteration {iteration} ======")
-        positioning_model.dump_object_positions(prefix="\t")
-
-        loss = positioning_model()
-        print(f"\tLoss: {loss.item()}")
-        loss.backward()
-
-        optimizer.step()
-        optimizer.zero_grad()
-
-        learning_rate_schedule.step(loss)
-
-    print("========= Final Positions ========")
-    positioning_model.dump_object_positions(prefix="\t")
-
-
 def run_model(
     objs: List[AdamObject], num_iterations: int = 200, yield_steps: Optional[int] = None
 ) -> Generator[List[torch.Tensor], None, List[torch.Tensor]]:
@@ -556,7 +516,3 @@ class CollisionPenalty(nn.Module):  # type: ignore
 
         # overlap is represented by a negative value, which we return as a positive penalty
         return overlap_distance.max() * -1 * COLLISION_PENALTY
-
-
-if __name__ == "__main__":
-    main()

--- a/adam/visualization/positioning.py
+++ b/adam/visualization/positioning.py
@@ -1,0 +1,432 @@
+"""
+This module defines a bounding box type and implements a constraint solver
+that can position multiple bounding boxes s/t they do not overlap
+(in addition to other constraints).
+"""
+from itertools import combinations
+from typing import Mapping, AbstractSet
+from attr import attrs, attrib
+
+import numpy as np
+from numpy import ndarray
+import torch
+import torch.nn as nn
+from torch.nn import Parameter
+import torch.optim as optim
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+from immutablecollections import immutabledict, immutableset, ImmutableDict
+from vistautils.preconditions import check_arg
+
+# see https://github.com/pytorch/pytorch/issues/24807 re: pylint issue
+ORIGIN = torch.zeros(3, dtype=torch.float)  # pylint: disable=not-callable
+COLLISION_PENALTY = 10
+
+
+@attrs(frozen=True, auto_attribs=True)
+class AdamObject:
+    """Used for testing purposes, to attach a name to a bounding box"""
+
+    name: str
+
+
+def main() -> None:
+    ball = AdamObject(name="ball")
+    box = AdamObject(name="box")
+
+    cardboard_box = AdamObject(name="cardboardBox")
+    aardvark = AdamObject(name="aardvark")
+    flamingo = AdamObject(name="flamingo")
+
+    positioning_model = AdamObjectPositioningModel.for_objects(
+        immutableset([ball, box, cardboard_box, aardvark, flamingo])
+    )
+    # we will start with an aggressive learning rate
+    optimizer = optim.SGD(positioning_model.parameters(), lr=1.0)
+    # but will decrease it whenever the loss plateaus
+    learning_rate_schedule = ReduceLROnPlateau(
+        optimizer,
+        "min",
+        # decrease the rate if the loss hasn't improved in
+        # 3 epochs
+        patience=3,
+    )
+
+    iterations = 25
+    for _ in range(iterations):
+        loss = positioning_model()
+        print(f"Loss: {loss.item()}")
+        loss.backward()
+
+        optimizer.step()
+        optimizer.zero_grad()
+
+        learning_rate_schedule.step(loss)
+
+        positioning_model.dump_object_positions()
+
+
+@attrs(frozen=True, slots=True)
+class AxisAlignedBoundingBox:
+    """
+    Defines a 3D Box that is oriented to world axes.
+
+    This box is defined by a center point of shape (3,),
+    and a scale (also of shape (3,)) which defines how a unit cube
+    with the given center will be scaled in each dimension to create
+    this box.
+
+    For example: a box centered at (0, 0, 0) and with a scale of (1, 1, 1) would have opposite
+    corners at (-1, -1, -1) and (1, 1, 1), giving the box a volume of 2(^3)
+    """
+
+    center: torch.Tensor = attrib()  # tensor shape: (3,)
+    scale: torch.Tensor = attrib()  # tensor shape: (3, 3) - diagonal matrix
+    # rotation: torch.Tensor = attrib()
+
+    def center_distance_from_point(self, point: torch.Tensor) -> torch.Tensor:
+        return torch.dist(self.center, point, 2)
+
+    @staticmethod
+    def create_at_random_position(
+        *, min_distance_from_origin: float, max_distance_from_origin: float
+    ):
+        return AxisAlignedBoundingBox.create_at_random_position_scaled(
+            min_distance_from_origin=min_distance_from_origin,
+            max_distance_from_origin=max_distance_from_origin,
+            object_scale=torch.ones(3),
+        )
+
+    @staticmethod
+    def create_at_center_point(*, center: ndarray):
+        return AxisAlignedBoundingBox(
+            Parameter(
+                torch.tensor(center, dtype=torch.float),  # pylint: disable=not-callable
+                requires_grad=True,
+            ),
+            torch.diag(torch.ones(3)),
+        )
+
+    @staticmethod
+    def create_at_random_position_scaled(
+        *,
+        min_distance_from_origin: float,
+        max_distance_from_origin: float,
+        object_scale: torch.Tensor,
+    ):
+        check_arg(min_distance_from_origin > 0.0)
+        check_arg(min_distance_from_origin < max_distance_from_origin)
+        # we first generate a random point on the unit sphere by
+        # generating a random vector in cube...
+        center = np.random.randn(3, 1).squeeze()
+        # and then normalizing.
+        center /= np.linalg.norm(center)
+
+        # then we scale according to the distances above
+        scale_factor = np.random.uniform(
+            min_distance_from_origin, max_distance_from_origin
+        )
+        center *= scale_factor
+        return AxisAlignedBoundingBox(
+            Parameter(
+                torch.tensor(center, dtype=torch.float),  # pylint: disable=not-callable
+                requires_grad=True,
+            ),
+            torch.diag(object_scale),
+        )
+
+    def get_corners(self) -> torch.Tensor:
+        return self.center.expand(8, 3) + torch.tensor(  # pylint: disable=not-callable
+            [
+                [-1, -1, -1],
+                [1, -1, -1],
+                [-1, 1, -1],
+                [1, 1, -1],
+                [-1, -1, 1],
+                [1, -1, 1],
+                [-1, 1, 1],
+                [1, 1, 1],
+            ],
+            dtype=torch.float,
+        ).matmul(self.scale)
+        # see https://github.com/pytorch/pytorch/issues/24807 re: pylint issue
+
+    def _minus_ones_corner(self) -> torch.Tensor:
+        """
+        Corner in the direction of the negative x, y, z axes from center
+        Returns: Tensor (3,)
+
+        """
+        return self.center + torch.tensor(  # pylint: disable=not-callable
+            [-1, -1, -1], dtype=torch.float
+        ).matmul(self.scale)
+
+    # functions returning normal vectors from three perpendicular faces of the box
+    def right_face_normal_vector(self) -> torch.Tensor:
+        """
+        Normal vector for the right face of the box (toward positive x axis when aligned to world axes)
+        Returns: Tensor (3,)
+        """
+        diff = (
+            self.center
+            + torch.tensor(  # pylint: disable=not-callable
+                [1, -1, -1], dtype=torch.float
+            ).matmul(self.scale)
+            - self._minus_ones_corner()
+        )
+        return diff / torch.norm(diff)
+
+    def forward_face_normal_vector(self) -> torch.Tensor:
+        """
+        Normal vector for the forward face of the box (toward positive y axis when aligned to world axes)
+        Returns: Tensor (3,)
+        """
+        diff = (
+            self.center
+            + torch.tensor(  # pylint: disable=not-callable
+                [-1, 1, -1], dtype=torch.float
+            ).matmul(self.scale)
+            - self._minus_ones_corner()
+        )
+        return diff / torch.norm(diff)
+
+    def up_face_normal_vector(self) -> torch.Tensor:
+        """
+        Normal vector for the up face of the box (toward positive z axis when aligned to world axes)
+        Returns: Tensor (3,)
+        """
+        diff = (
+            self.center
+            + torch.tensor(  # pylint: disable=not-callable
+                [-1, -1, 1], dtype=torch.float
+            ).matmul(self.scale)
+            - self._minus_ones_corner()
+        )
+        return diff / torch.norm(diff)
+
+    def face_normal_vectors(self) -> torch.Tensor:
+        """
+        Stacks the face norms from the right, forward, and up faces of the box
+        Returns: Tensor (3,3)
+
+        """
+        # in axis-aligned case these are always the same
+        return torch.stack(
+            [
+                self.right_face_normal_vector(),
+                self.forward_face_normal_vector(),
+                self.up_face_normal_vector(),
+            ]
+        )
+
+    def corners_onto_axes_projections(self, axes: torch.Tensor) -> torch.Tensor:
+        """
+        Projects each of 8 corners onto each of three axes.
+        Args:
+            axes: (3,3) tensor -> the three axes we are projecting points onto
+
+        Returns:
+            (3, 8) tensor -> each point projected onto each of three dimensions
+
+        """
+        check_arg(axes.shape == (3, 3))
+        corners = self.get_corners()
+        return axes.matmul(corners.transpose(0, 1))
+
+
+class AdamObjectPositioningModel(torch.nn.Module):  # type: ignore
+    """
+    Model that combines multiple constraints on AxisAlignedBoundingBoxes.
+    """
+
+    def __init__(
+        self, adam_object_to_bounding_box: Mapping[AdamObject, AxisAlignedBoundingBox]
+    ) -> None:
+        super().__init__()
+        self.adam_object_to_bounding_box = adam_object_to_bounding_box
+        self.object_bounding_boxes = adam_object_to_bounding_box.values()
+
+        for (adam_object, bounding_box) in self.adam_object_to_bounding_box.items():
+            self.register_parameter(
+                adam_object.name, Parameter(bounding_box.center, requires_grad=True)
+            )
+
+        self.distance_to_origin_penalty = DistanceFromOriginPenalty()
+        self.collision_penalty = CollisionPenalty()
+
+    @staticmethod
+    def for_objects(
+        adam_objects: AbstractSet[AdamObject]
+    ) -> "AdamObjectPositioningModel":
+        objects_to_bounding_boxes: ImmutableDict[
+            AdamObject, AxisAlignedBoundingBox
+        ] = immutabledict(
+            (
+                adam_object,
+                AxisAlignedBoundingBox.create_at_random_position(
+                    min_distance_from_origin=5, max_distance_from_origin=10
+                ),
+            )
+            for adam_object in adam_objects
+        )
+        return AdamObjectPositioningModel(objects_to_bounding_boxes)
+
+    def forward(self):  # pylint: disable=arguments-differ
+        distance_penalty = sum(
+            self.distance_to_origin_penalty(box) for box in self.object_bounding_boxes
+        )
+        collision_penalty = sum(
+            self.collision_penalty(box1, box2)
+            for (box1, box2) in combinations(self.object_bounding_boxes, 2)
+        )
+        print(
+            f"distance penalty: {distance_penalty}\ncollision penalty: {collision_penalty}"
+        )
+        return distance_penalty + collision_penalty
+
+    def dump_object_positions(self) -> None:
+        for (adam_object, bounding_box) in self.adam_object_to_bounding_box.items():
+            print(f"{adam_object.name} = {bounding_box.center.data}")
+
+
+class DistanceFromOriginPenalty(nn.Module):  # type: ignore
+    """
+    Model that penalizes boxes that are distant from the origin.
+    """
+
+    def __init__(self) -> None:  # pylint: disable=useless-super-delegation
+        super().__init__()
+
+    def forward(self, *inputs):  # pylint: disable=arguments-differ
+        bounding_box: AxisAlignedBoundingBox = inputs[0]
+        return bounding_box.center_distance_from_point(ORIGIN)
+
+
+class CollisionPenalty(nn.Module):  # type: ignore
+    """
+    Model that penalizes boxes that are colliding with other boxes.
+    """
+
+    def __init__(self):  # pylint: disable=useless-super-delegation
+        super().__init__()
+
+    def forward(self, *inputs):  # pylint: disable=arguments-differ
+        bounding_box_1: AxisAlignedBoundingBox = inputs[0]
+        bounding_box_2: AxisAlignedBoundingBox = inputs[1]
+
+        # get face norms from one of the boxes:
+        face_norms = bounding_box_2.face_normal_vectors()
+
+        return CollisionPenalty.overlap_penalty(
+            CollisionPenalty.get_min_max_overlaps(
+                CollisionPenalty.get_min_max_corner_projections(
+                    bounding_box_1.corners_onto_axes_projections(face_norms)
+                ),
+                CollisionPenalty.get_min_max_corner_projections(
+                    bounding_box_2.corners_onto_axes_projections(face_norms)
+                ),
+            )
+        )
+
+    @staticmethod
+    def get_min_max_corner_projections(projections: torch.Tensor):
+        """
+        Retrieve the minimum and maximum corner projection (min/max extent in that dimension) for each axis
+        Args:
+            projections: Tensor(3, 8) -> corner projections onto each of three dimensions
+
+        Returns:
+            Tensor(3, 2) -> (min, max) values for each of three dimensions
+
+        """
+        check_arg(projections.shape == (3, 8))
+
+        min_indices = torch.min(projections, 1)
+        max_indices = torch.max(projections, 1)
+        # these are tuples of (values, indices), both of which are tensors
+
+        # helper variable for representing dimension numbers
+        # see https://github.com/pytorch/pytorch/issues/24807 re: pylint issue
+        dims = torch.tensor([0, 1, 2], dtype=torch.int)  # pylint: disable=not-callable
+        # select the indexed items (from a 24 element tensor)
+        minima = torch.take(projections, min_indices[1] + (dims * 8))
+        maxima = torch.take(projections, max_indices[1] + (dims * 8))
+        # stack the minim
+        return torch.stack((minima, maxima), 1)
+
+    @staticmethod
+    def get_min_max_overlaps(
+        min_max_proj_0: torch.Tensor, min_max_proj_1: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Given min/max corner projections onto 3 axes from two different objects,
+        return an interval for each dimension representing the degree of overlap or
+        separation between the two objects.
+        Args:
+            min_max_proj_0: Tensor(3,2) min_max_projections for box 0
+            min_max_proj_1: Tensor(3,2) min_max projections for box 1
+
+        Returns:
+            (3, 2) tensor -> ranges (start, end) of overlap OR separation in each of three dimensions.
+            If (start - end) is positive, this indicates that the boxes do not overlap along this dimension,
+            otherwise, a negative value indicates an overlap along that dimension.
+        """
+        check_arg(min_max_proj_0.shape == (3, 2))
+        check_arg(min_max_proj_1.shape == (3, 2))
+
+        # see https://github.com/pytorch/pytorch/issues/24807 re: pylint issue
+        dims = torch.tensor([0, 1, 2], dtype=torch.int)  # pylint: disable=not-callable
+
+        mins_0 = min_max_proj_0.gather(1, torch.zeros((3, 1), dtype=torch.long))
+        mins_1 = min_max_proj_1.gather(1, torch.zeros((3, 1), dtype=torch.long))
+
+        combined_mins = torch.stack((mins_0, mins_1), 1).squeeze()
+        max_indices = torch.max(combined_mins, 1)
+        maximum_mins = torch.take(combined_mins, max_indices[1] + (dims * 2))
+
+        # should stick together the minimum parts and the maximum parts
+        # with columns like:
+        # [ min0x   min1x
+        #   min0y   min1y
+        #   min0z   min1z
+        #                ]
+        # then find the maximum element from each row
+
+        # repeat the process for the min of the max projections
+        maxs_0 = min_max_proj_0.gather(1, torch.ones((3, 1), dtype=torch.long))
+        maxs_1 = min_max_proj_1.gather(1, torch.ones((3, 1), dtype=torch.long))
+        combined_maxes = torch.stack((maxs_0, maxs_1), 1).squeeze()
+        min_indices = torch.min(combined_maxes, 1)
+        minimum_maxes = torch.take(combined_maxes, min_indices[1] + (dims * 2))
+
+        return torch.stack((maximum_mins, minimum_maxes), 1)
+
+    @staticmethod
+    def overlap_penalty(min_max_overlaps: torch.Tensor) -> torch.Tensor:
+        """
+        Return penalty depending on degree of overlap between two 3d boxes.
+        Args:
+            min_max_overlaps: (3, 2) tensor -> intervals describing degree of overlap between the two boxes
+
+        Returns: Tensor with a positive scalar of the collision penalty, or tensor with zero scalar
+        for no collision.
+        """
+        check_arg(min_max_overlaps.shape == (3, 2))
+        # subtract each minimum max from each maximum min:
+        overlap_distance = min_max_overlaps[:, 0] - min_max_overlaps[:, 1]
+
+        # as long as at least one dimension's overlap distance is positive (not overlapping),
+        # then the boxes are not colliding
+        for dim in range(3):
+            if overlap_distance[dim] >= 0:
+                return torch.zeros(1, dtype=torch.float)
+
+        # otherwise the penetration distance is the maximum negative value
+        # (the smallest translation that would disentangle the two
+
+        # overlap is represented by a negative value, which we return as a positive penalty
+        return overlap_distance.max() * -1 * COLLISION_PENALTY
+
+
+if __name__ == "__main__":
+    main()

--- a/parameters/make_scenes.params
+++ b/parameters/make_scenes.params
@@ -1,0 +1,3 @@
+iterations: 200
+steps_before_vis: 20
+seed: 2020

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ graphviz==0.13
 
 # for the demo visualization
 panda3d==1.10.4.1
+torch==1.3.1
+numpy==1.17.3
+scipy==1.3.1
+
 
 # extras for development
 black==18.9b0

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -8,7 +8,9 @@ from adam.perception.high_level_semantics_situation_to_developmental_primitive_p
 from typing import Tuple
 
 
-def test_scenes_creation() -> Tuple[float, float, float]:
+def test_scenes_creation() -> Tuple[
+    Tuple[float, float, float], Tuple[float, float, float]
+]:
     for i, (_, obj_graph) in enumerate(
         SceneCreator.create_scenes(build_gaila_phase_1_curriculum())
     ):
@@ -38,4 +40,4 @@ def test_scenes_creation() -> Tuple[float, float, float]:
         # automated test shouldn't go through every single scene
         if i > 5:
             break
-    return root_point, point
+    return point, root_point

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -1,22 +1,17 @@
 from adam.curriculum.phase1_curriculum import build_gaila_phase_1_curriculum
 from adam.visualization.make_scenes import SceneCreator
-from adam.visualization.utils import Shape
+
 from typing import Tuple
 
 
 def test_scenes_creation() -> Tuple[float, float, float]:
-    for i, scene in enumerate(
+    for i, (_, obj_graph) in enumerate(
         SceneCreator.create_scenes(build_gaila_phase_1_curriculum())
     ):
-        for obj, _ in scene.items():
-            # only interested in rendering geons
-            if (
-                obj.geon is None
-                or SceneCreator.cross_section_to_geo(obj.geon.cross_section)
-                == Shape.IRREGULAR
-            ):
-                continue
-            point = SceneCreator.random_position()
+        SceneCreator.graph_for_each(obj_graph, lambda g: None)
+
+        point = SceneCreator.random_position()
+
         # automated test shouldn't go through every single scene
         if i > 5:
             break

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -1,6 +1,10 @@
 from adam.curriculum.phase1_curriculum import build_gaila_phase_1_curriculum
 from adam.visualization.make_scenes import SceneCreator
-
+from adam.geon import CrossSection
+from adam.visualization.utils import Shape
+from adam.perception.high_level_semantics_situation_to_developmental_primitive_perception import (
+    ObjectPerception,
+)
 from typing import Tuple
 
 
@@ -8,7 +12,24 @@ def test_scenes_creation() -> Tuple[float, float, float]:
     for i, (_, obj_graph) in enumerate(
         SceneCreator.create_scenes(build_gaila_phase_1_curriculum())
     ):
-        SceneCreator.graph_for_each(obj_graph, lambda g: None)
+
+        def test_for_each(obj: ObjectPerception) -> None:
+            print(obj.debug_handle)
+
+        def test_for_each_nested_really_nested(obj: ObjectPerception, other: str) -> str:
+            print(obj.debug_handle)
+            return other
+
+        def test_cs_to_shape(cs: CrossSection) -> Shape:
+            return SceneCreator.cross_section_to_geo(cs)
+
+        SceneCreator.graph_for_each(obj_graph, test_for_each)
+        SceneCreator.graph_for_each_top_level(
+            obj_graph, test_for_each, test_for_each_nested_really_nested
+        )
+        for obj in obj_graph:
+            if obj.elt.geon:
+                test_cs_to_shape(obj.elt.geon.cross_section)
 
         point = SceneCreator.random_position()
 

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -33,6 +33,8 @@ def test_scenes_creation() -> Tuple[float, float, float]:
 
         point = SceneCreator.random_leaf_position()
 
+        root_point = SceneCreator.random_root_position()
+
         # automated test shouldn't go through every single scene
         if i > 5:
             break

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -28,8 +28,8 @@ def test_scenes_creation() -> Tuple[float, float, float]:
             obj_graph, test_for_each, test_for_each_nested_really_nested
         )
         for obj in obj_graph:
-            if obj.elt.geon:
-                test_cs_to_shape(obj.elt.geon.cross_section)
+            if obj.perceived_obj.geon:
+                test_cs_to_shape(obj.perceived_obj.geon.cross_section)
 
         point = SceneCreator.random_leaf_position()
 

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -38,4 +38,4 @@ def test_scenes_creation() -> Tuple[float, float, float]:
         # automated test shouldn't go through every single scene
         if i > 5:
             break
-    return point
+    return root_point, point

--- a/tests/visualization/make_scenes_test.py
+++ b/tests/visualization/make_scenes_test.py
@@ -31,7 +31,7 @@ def test_scenes_creation() -> Tuple[float, float, float]:
             if obj.elt.geon:
                 test_cs_to_shape(obj.elt.geon.cross_section)
 
-        point = SceneCreator.random_position()
+        point = SceneCreator.random_leaf_position()
 
         # automated test shouldn't go through every single scene
         if i > 5:

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -11,19 +11,23 @@ def test_basic_3d_scene() -> None:
     app = SituationVisualizer()
     app.test_scene_init()
 
-    app.add_model(Shape.SQUARE, (1, 2, 2))
-    app.add_model(Shape.RECTANGULAR, (2, 2, 2))
+    app.add_model(Shape.SQUARE, name="Square0", position=(1, 2, 2))
+    app.add_model(Shape.RECTANGULAR, name="rect0", position=(2, 2, 2))
     try:
-        app.add_model(Shape.IRREGULAR, (4, 4, 4))
+        app.add_model(Shape.IRREGULAR, name="irreg0", position=(4, 4, 4))
     except KeyError:
         pass
-    oval = app.add_model(Shape.OVALISH, (5, 5, 5))
-    app.add_model(Shape.CIRCULAR, (7, 7, 7), col=None, parent=oval)
+    oval = app.add_model(Shape.OVALISH, name="oval0", position=(5, 5, 5))
+    app.add_model(
+        Shape.CIRCULAR, name="sphere0", position=(7, 7, 7), color=None, parent=oval
+    )
 
     app.print_scene_graph()
 
     dummy_node = app.add_dummy_node("dummy", (0, 0, 0))
-    other_dummy_node = app.add_dummy_node("second_dummy", (0, 0, 0), dummy_node)
+    other_dummy_node = app.add_dummy_node(
+        "second_dummy", position=(0, 0, 0), parent=dummy_node
+    )
 
     print(other_dummy_node)
 
@@ -31,8 +35,8 @@ def test_basic_3d_scene() -> None:
 
     app.clear_scene()
 
-    app.add_model(Shape.RECTANGULAR, (-2, 2, 2))
+    app.add_model(Shape.RECTANGULAR, name="rect", position=(-2, 2, 2))
 
-    app.add_model(Shape.CIRCULAR, (0, 0, 8))
+    app.add_model(Shape.CIRCULAR, name="sphere", position=(0, 0, 8))
 
-    app.add_model(Shape.OVALISH, (4, 5, 2))
+    app.add_model(Shape.OVALISH, name="oval", position=(4, 5, 2))

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -23,7 +23,7 @@ def test_basic_3d_scene() -> None:
     app.print_scene_graph()
 
     dummy_node = app.add_dummy_node("dummy", (0, 0, 0))
-    other_dummy_node = app.add_dummy_node("second_dummy", dummy_node)
+    other_dummy_node = app.add_dummy_node("second_dummy", (0, 0, 0), dummy_node)
 
     print(other_dummy_node)
 

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -3,6 +3,7 @@ from pandac.PandaModules import ConfigVariableString  # pylint: disable=no-name-
 from adam.visualization.panda3d_interface import SituationVisualizer
 from adam.visualization.utils import Shape
 
+# sets the rendering engine to not run, as it can't be handled by CI system
 ConfigVariableString("window-type", "none").setValue("none")
 
 # This should be the only test to actually instantiate panda3d

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -11,19 +11,27 @@ def test_basic_3d_scene() -> None:
     app.test_scene_init()
 
     app.add_model(Shape.SQUARE, (1, 2, 2))
+    app.add_model(Shape.RECTANGULAR, (2, 2, 2))
+    try:
+        app.add_model(Shape.IRREGULAR, (4, 4, 4))
+    except KeyError:
+        pass
+    oval = app.add_model(Shape.OVALISH, (5, 5, 5))
+    app.add_model(Shape.CIRCULAR, (7, 7, 7), col=None, parent=oval)
 
-    # app.run_for_seconds(0.25)
+    app.print_scene_graph()
 
-    # app.run_for_seconds(0.25)
+    dummy_node = app.add_dummy_node("dummy")
+    other_dummy_node = app.add_dummy_node("second_dummy", dummy_node)
+
+    print(other_dummy_node)
+
+    app.test_scene_init()
 
     app.clear_scene()
-
-    # app.run_for_seconds(0.25)
 
     app.add_model(Shape.RECTANGULAR, (-2, 2, 2))
 
     app.add_model(Shape.CIRCULAR, (0, 0, 8))
 
     app.add_model(Shape.OVALISH, (4, 5, 2))
-
-    # app.run_for_seconds(0.25)

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -9,7 +9,6 @@ ConfigVariableString("window-type", "none").setValue("none")
 # This should be the only test to actually instantiate panda3d
 def test_basic_3d_scene() -> None:
     app = SituationVisualizer()
-    app.test_scene_init()
 
     app.add_model(Shape.SQUARE, name="Square0", position=(1, 2, 2))
     app.add_model(Shape.RECTANGULAR, name="rect0", position=(2, 2, 2))
@@ -30,8 +29,6 @@ def test_basic_3d_scene() -> None:
     )
 
     print(other_dummy_node)
-
-    app.test_scene_init()
 
     app.clear_scene()
 

--- a/tests/visualization/panda_interface_test.py
+++ b/tests/visualization/panda_interface_test.py
@@ -21,7 +21,7 @@ def test_basic_3d_scene() -> None:
 
     app.print_scene_graph()
 
-    dummy_node = app.add_dummy_node("dummy")
+    dummy_node = app.add_dummy_node("dummy", (0, 0, 0))
     other_dummy_node = app.add_dummy_node("second_dummy", dummy_node)
 
     print(other_dummy_node)

--- a/tests/visualization/positioning_test.py
+++ b/tests/visualization/positioning_test.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from adam.visualization.positioning import (
+    AxisAlignedBoundingBox,
+    CollisionPenalty,
+    DistanceFromOriginPenalty,
+)
+
+# re-use in-module test:
+from adam.visualization.positioning import main as optimization_test
+
+
+def test_optimization() -> None:
+    # Check that the position optimization system runs without crashing
+    np.random.seed(127)
+    optimization_test()
+
+
+def test_collision_constraint() -> None:
+    # positioned to be colliding with one another:
+    aabb0 = AxisAlignedBoundingBox.create_at_center_point(center=np.array([0, 0, 0]))
+    aabb1 = AxisAlignedBoundingBox.create_at_center_point(
+        center=np.array([0.5, 0.5, 0.5])
+    )
+
+    # positioned to not be colliding
+    aabb_far = AxisAlignedBoundingBox.create_at_center_point(center=np.array([50, 0, 0]))
+
+    collision_penalty = CollisionPenalty()
+
+    res = collision_penalty.forward(aabb0, aabb1)
+    assert res > 0
+
+    res = collision_penalty.forward(aabb0, aabb_far)
+
+    assert res <= 0
+
+
+def test_distance_constraint() -> None:
+    aabb0 = AxisAlignedBoundingBox.create_at_center_point(center=np.array([0, 0, 0]))
+    aabb_far = AxisAlignedBoundingBox.create_at_center_point(center=np.array([50, 0, 0]))
+
+    # this penalty is the Euclidean distance of the box from the origin
+    distance_from_origin = DistanceFromOriginPenalty()
+
+    aabb_far_dist = distance_from_origin(aabb_far)
+    aabb0_dist = distance_from_origin(aabb0)
+
+    # aabb_far should be further from the origin than aabb0
+    assert aabb_far_dist > aabb0_dist
+
+    # check the distances of the boxes
+    assert aabb_far_dist.item() == pytest.approx(50.0)
+    assert aabb0_dist.item() == pytest.approx(0.0)

--- a/tests/visualization/positioning_test.py
+++ b/tests/visualization/positioning_test.py
@@ -4,16 +4,20 @@ from adam.visualization.positioning import (
     AxisAlignedBoundingBox,
     CollisionPenalty,
     WeakGravityPenalty,
+    AdamObject,
+    run_model,
 )
 
-# re-use in-module test:
-from adam.visualization.positioning import main as optimization_test
 
+def test_running_model() -> None:
+    # for code coverage purposes
+    ball = AdamObject(name="ball", initial_position=(0, 0, 10))
+    box = AdamObject(name="box", initial_position=(0, 0, 1))
 
-def test_optimization() -> None:
-    # Check that the position optimization system runs without crashing
-    np.random.seed(127)
-    optimization_test()
+    aardvark = AdamObject(name="aardvark", initial_position=(1, 2, 1))
+    flamingo = AdamObject(name="flamingo", initial_position=(-1, 1, 2))
+    objs = [ball, box, aardvark, flamingo]
+    run_model(objs, num_iterations=10, yield_steps=10)
 
 
 def test_collision_constraint() -> None:

--- a/tests/visualization/positioning_test.py
+++ b/tests/visualization/positioning_test.py
@@ -1,10 +1,9 @@
 import numpy as np
-import pytest
 
 from adam.visualization.positioning import (
     AxisAlignedBoundingBox,
     CollisionPenalty,
-    DistanceFromOriginPenalty,
+    WeakGravityPenalty,
 )
 
 # re-use in-module test:
@@ -37,19 +36,20 @@ def test_collision_constraint() -> None:
     assert res <= 0
 
 
-def test_distance_constraint() -> None:
-    aabb0 = AxisAlignedBoundingBox.create_at_center_point(center=np.array([0, 0, 0]))
-    aabb_far = AxisAlignedBoundingBox.create_at_center_point(center=np.array([50, 0, 0]))
+def test_gravity_constraint() -> None:
+    aabb_floating = AxisAlignedBoundingBox.create_at_center_point(
+        center=np.array([0, 0, 5])
+    )
 
-    # this penalty is the Euclidean distance of the box from the origin
-    distance_from_origin = DistanceFromOriginPenalty()
+    # boxes are 2 units tall by default, so this one is resting on the ground
+    aabb_grounded = AxisAlignedBoundingBox.create_at_center_point(
+        center=np.array([0, 0, 1])
+    )
 
-    aabb_far_dist = distance_from_origin(aabb_far)
-    aabb0_dist = distance_from_origin(aabb0)
+    gravity_penalty = WeakGravityPenalty()
 
-    # aabb_far should be further from the origin than aabb0
-    assert aabb_far_dist > aabb0_dist
+    floating_result = gravity_penalty(aabb_floating)
+    assert floating_result > 0
 
-    # check the distances of the boxes
-    assert aabb_far_dist.item() == pytest.approx(50.0)
-    assert aabb0_dist.item() == pytest.approx(0.0)
+    grounded_result = gravity_penalty(aabb_grounded)
+    assert grounded_result <= 0


### PR DESCRIPTION
Closes #392 original issue was due to some of the 'people' in scenes not having any properties attached to their arms/legs/etc (no color, no animacy, etc), not due to any nesting issues.

The new method of traversing all objects in a scene to find objects with geons gets around the issue of some objects not having any properties.

At any rate, the goal with this PR is to come up with a nested representation for scene objects that are `partOf` others so that later on they can be positioned/oriented/scaled relative to their parent object.