### PR TITLE
Ignore test coverage checks for Visualization source files

### DIFF
--- a/.coveragec
+++ b/.coveragec
@@ -4,6 +4,8 @@ source = adam
 
 [report]
 exclude_lines =
+    # Dont test lines with this comment
+    pragma: no cover
     if self.debug:
     pragma: no cover
     raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,6 @@ source = adam
 
 [report]
 exclude_lines =
-    # Dont test lines with this comment
-    pragma: no cover
     if self.debug:
     pragma: no cover
     raise NotImplementedError
@@ -13,3 +11,4 @@ exclude_lines =
 ignore_errors = True
 omit =
     tests/*
+    adam/visualization/*

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -1,3 +1,4 @@
+#pragma: no cover
 """This module is responsible for feeding Scenes from a Curriculum into
    a rendering system to be displayed. It manages *when* the renderer is
    operating and when other code (gathering and processing scene information)

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -1,4 +1,4 @@
-#pragma: no cover
+# pragma: no cover
 """This module is responsible for feeding Scenes from a Curriculum into
    a rendering system to be displayed. It manages *when* the renderer is
    operating and when other code (gathering and processing scene information)

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -1,4 +1,4 @@
-#pragma: no cover
+# pragma: no cover
 """Main interface for Panda3D rendering.
    Executing this module meant for testing purposes. (viewing an object in isolation)
    Defines various default settings (ground plane, lighting, camera

--- a/adam/visualization/panda3d_interface.py
+++ b/adam/visualization/panda3d_interface.py
@@ -1,3 +1,4 @@
+#pragma: no cover
 """Main interface for Panda3D rendering.
    Executing this module meant for testing purposes. (viewing an object in isolation)
    Defines various default settings (ground plane, lighting, camera

--- a/adam/visualization/positioning.py
+++ b/adam/visualization/positioning.py
@@ -1,3 +1,4 @@
+#pragma: no cover
 """
 This module defines a bounding box type and implements a constraint solver
 that can position multiple bounding boxes s/t they do not overlap

--- a/adam/visualization/positioning.py
+++ b/adam/visualization/positioning.py
@@ -1,4 +1,4 @@
-#pragma: no cover
+# pragma: no cover
 """
 This module defines a bounding box type and implements a constraint solver
 that can position multiple bounding boxes s/t they do not overlap

--- a/adam/visualization/utils.py
+++ b/adam/visualization/utils.py
@@ -1,4 +1,4 @@
-#pragma: no cover
+# pragma: no cover
 import enum
 from typing import Optional, List, Tuple
 from immutablecollections import immutableset, immutabledict, ImmutableDict

--- a/adam/visualization/utils.py
+++ b/adam/visualization/utils.py
@@ -1,3 +1,4 @@
+#pragma: no cover
 import enum
 from typing import Optional, List, Tuple
 from immutablecollections import immutableset, immutabledict, ImmutableDict


### PR DESCRIPTION
Generally speaking, the visualization system has some strange execution paths that make it unsuitable for some of our CI tools -- i.e. Travis can't open up a graphics window to test those parts of the code)