### PR TITLE
Restore disabled error message for patterns matching multiple connected components

### DIFF
--- a/adam/perception/perception_graph.py
+++ b/adam/perception/perception_graph.py
@@ -1207,12 +1207,11 @@ class PatternMatching:
                     graph_logger.log_match_failure(
                         match_failure, logging.INFO, "Pattern match component failure"
                     )
-                return None
-                # raise RuntimeError(
-                #     f"Expected the successfully matching portion of the pattern"
-                #     f" to belong to a single connected component, but it was in "
-                #     f"{connected_components_containing_successful_pattern_matches}"
-                # )
+                raise RuntimeError(
+                    f"Expected the successfully matching portion of the pattern"
+                    f" to belong to a single connected component, but it was in "
+                    f"{connected_components_containing_successful_pattern_matches}"
+                )
 
             logging.info(
                 "Relaxation: deleted due to disconnection: %s",


### PR DESCRIPTION
…during pattern generalization -- m6 ran w/o raising it. Closes #512 

