### PR TITLE
Corrected implicit ground relation to consider before and after action relations

### DIFF
--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -260,7 +260,9 @@ class _PerceptionGeneration:
 
         if not self._situation.actions:
             if self._include_ground:
-                self._relation_perceptions.extend(self._perceive_ground_relations(self._relation_perceptions))
+                self._relation_perceptions.extend(
+                    self._perceive_ground_relations(self._relation_perceptions)
+                )
             return PerceptualRepresentation.single_frame(
                 DevelopmentalPrimitivePerceptionFrame(
                     perceived_objects=self._object_perceptions,

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -764,7 +764,7 @@ class _PerceptionGeneration:
             if situation_object.ontology_node != GROUND:
                 if self._objects_to_perceptions[situation_object] in objects_to_relations:
                     # If this object is not on anything else, it should be on the ground
-                    object_is_on_something = False
+                    object_is_on_ground = True
                     for relation in objects_to_relations[
                         self._objects_to_perceptions[situation_object]
                     ]:
@@ -775,9 +775,9 @@ class _PerceptionGeneration:
                             if (
                                 region.distance == EXTERIOR_BUT_IN_CONTACT
                                 and region.direction == GRAVITATIONAL_UP
-                            ):
-                                object_is_on_something = True
-                    if not object_is_on_something:
+                            ) or region.distance == INTERIOR:
+                                object_is_on_ground = False
+                    if object_is_on_ground:
                         ground_relations.extend(
                             on(
                                 self._objects_to_perceptions[situation_object],

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -286,6 +286,7 @@ class _PerceptionGeneration:
 
         # Add ground for always perception if needed
         if self._include_ground:
+            # Grabbing any "always" ground relations
             self._relation_perceptions.extend(
                 self._perceive_ground_relations(
                     relations=chain(
@@ -297,6 +298,8 @@ class _PerceptionGeneration:
                     )
                 )
             )
+            # Due to the presence of an action need to specify implicit ground relations before and
+            # after the action seperately.
             before_ground = self._perceive_ground_relations(
                 relations=chain(
                     self._relation_perceptions,
@@ -747,7 +750,9 @@ class _PerceptionGeneration:
             self._objects_to_perceptions
         )
 
-    def _perceive_ground_relations(self, relations: Iterable[Relation[ObjectPerception]]):
+    def _perceive_ground_relations(
+        self, relations: Iterable[Relation[ObjectPerception]]
+    ) -> ImmutableSet[Relation[ObjectPerception]]:
         objects_to_relations = self._objects_to_relations(relations)
         ground_relations: List[Relation[ObjectPerception]] = []
         perceived_ground: Optional[ObjectPerception] = None
@@ -773,21 +778,21 @@ class _PerceptionGeneration:
                             ):
                                 object_is_on_something = True
                     if not object_is_on_something:
-                        ground_relations.append(
+                        ground_relations.extend(
                             on(
                                 self._objects_to_perceptions[situation_object],
                                 perceived_ground,
-                            )[0]
+                            )
                         )
                 else:
-                    ground_relations.append(
+                    ground_relations.extend(
                         on(
                             self._objects_to_perceptions[situation_object],
                             perceived_ground,
-                        )[0]
+                        )
                     )
 
-        return ground_relations
+        return immutableset(ground_relations)
 
     def _objects_to_relations(
         self, relations: Iterable[Relation[ObjectPerception]]

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -764,7 +764,7 @@ class _PerceptionGeneration:
             if situation_object.ontology_node != GROUND:
                 if self._objects_to_perceptions[situation_object] in objects_to_relations:
                     # If this object is not on anything else, it should be on the ground
-                    object_is_on_ground = True
+                    object_is_on_or_in_something = False
                     for relation in objects_to_relations[
                         self._objects_to_perceptions[situation_object]
                     ]:
@@ -776,8 +776,8 @@ class _PerceptionGeneration:
                                 region.distance == EXTERIOR_BUT_IN_CONTACT
                                 and region.direction == GRAVITATIONAL_UP
                             ) or region.distance == INTERIOR:
-                                object_is_on_ground = False
-                    if object_is_on_ground:
+                                object_is_on_or_in_something = True
+                    if not object_is_on_or_in_something:
                         ground_relations.extend(
                             on(
                                 self._objects_to_perceptions[situation_object],

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -751,14 +751,14 @@ class _PerceptionGeneration:
                             ):
                                 object_is_on_something = True
                     if not object_is_on_something:
-                        self._relation_perceptions.append(
+                        self._relation_perceptions.append(  # type: ignore
                             on(
                                 self._objects_to_perceptions[situation_object],
                                 perceived_ground,
                             )
                         )
                 else:
-                    self._relation_perceptions.append(
+                    self._relation_perceptions.append(  # type: ignore
                         on(
                             self._objects_to_perceptions[situation_object],
                             perceived_ground,

--- a/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
+++ b/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
@@ -333,16 +333,7 @@ def test_grounding_of_unsupported_objects():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY,
         salient_objects=[box, ball],
-        always_relations=[
-            Relation(
-                IN_REGION,
-                ball,
-                Region(
-                    box,
-                    distance=INTERIOR,
-                ),
-            )
-        ],
+        always_relations=[Relation(IN_REGION, ball, Region(box, distance=INTERIOR))],
     )
 
     perception = _PERCEPTION_GENERATOR.generate_perception(
@@ -402,7 +393,7 @@ def test_dynamic_prepositions_implicit_grounding():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY,
         salient_objects=[baby, truck],
-        actions=[Action(FALL,  argument_roles_to_fillers=[(THEME, baby)])],
+        actions=[Action(FALL, argument_roles_to_fillers=[(THEME, baby)])],
         after_action_relations=[on(baby, truck)],
     )
 

--- a/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
+++ b/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
@@ -387,7 +387,6 @@ def test_objects_in_something_not_implcitly_grounded():
 
 
 def test_dynamic_prepositions_implicit_grounding():
-    # person_put_ball_on_table
     truck = situation_object(ontology_node=TRUCK)
     baby = situation_object(ontology_node=BABY)
     situation = HighLevelSemanticsSituation(
@@ -401,7 +400,7 @@ def test_dynamic_prepositions_implicit_grounding():
         situation, chooser=RandomChooser.for_seed(0)
     )
     first_frame = perception.frames[0]
-    baby_perception = perception_with_handle(first_frame, "person_0")
+    baby_perception = perception_with_handle(first_frame, "baby_0")
     ground_perception = perception_with_handle(first_frame, "the ground")
     truck_perception = perception_with_handle(first_frame, "truck_0")
 


### PR DESCRIPTION
- Changed `_perceived_ground_relations()` to take a relations parameter
so that before and after relations can be included
- Moved to `_perceived_ground_relations()` call from
`_perceive_action()` to `_real_do()` as to include all relations

Tested fix:
![image](https://user-images.githubusercontent.com/44595288/75462632-6c89ac00-597c-11ea-9a51-6fb58462f1a1.png)

Closes #596 