### PR TITLE
603 scaling people

### DIFF
--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -1049,6 +1049,9 @@ class _PerceptionGeneration:
 
         # find axes for the object
         if situation_object:
+            # use the debug handle from the situation object if it is available, as it is more
+            # specific in the case of people (e.g. mom, dad, baby) than the debug handle
+            # generated from the ObjectStructuralSchema
             debug_handle = (
                 situation_object.ontology_node.handle + "_" + debug_handle.split("_")[1]
             )

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -1030,9 +1030,17 @@ class _PerceptionGeneration:
         situation_object: Optional[SituationObject] = None,
     ) -> ObjectPerception:
 
-        debug_handle = self._object_handle_generator.subscripted_handle(
-            schema.ontology_node
-        )
+        # use the debug handle from the situation object if it is available, as it is more
+        # specific in the case of people (e.g. mom, dad, baby) than the debug handle
+        # generated from the ObjectStructuralSchema
+        if situation_object:
+            debug_handle = self._object_handle_generator.subscripted_handle(
+                situation_object.ontology_node
+            )
+        else:
+            debug_handle = self._object_handle_generator.subscripted_handle(
+                schema.ontology_node
+            )
 
         # find a geon for the object, if possible
         concrete_geon: Optional[Geon]
@@ -1049,12 +1057,6 @@ class _PerceptionGeneration:
 
         # find axes for the object
         if situation_object:
-            # use the debug handle from the situation object if it is available, as it is more
-            # specific in the case of people (e.g. mom, dad, baby) than the debug handle
-            # generated from the ObjectStructuralSchema
-            debug_handle = (
-                situation_object.ontology_node.handle + "_" + debug_handle.split("_")[1]
-            )
             # This is a top-level object which has already been assigned axes
             # by the situation. We should not change or copy them
             # or else references to them by the situation

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -1049,6 +1049,9 @@ class _PerceptionGeneration:
 
         # find axes for the object
         if situation_object:
+            debug_handle = (
+                situation_object.ontology_node.handle + "_" + debug_handle.split("_")[1]
+            )
             # This is a top-level object which has already been assigned axes
             # by the situation. We should not change or copy them
             # or else references to them by the situation

--- a/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
+++ b/tests/perception/high_level_semantics_situation_to_developmental_primitive_perception_test.py
@@ -614,7 +614,7 @@ def test_gaze_default():
     )
     frame = perception.frames[0]
     cookie_perception = perception_with_handle(frame, "cookie_0")
-    dad_perception = perception_with_handle(frame, "person_0")
+    dad_perception = perception_with_handle(frame, "dad_0")
     table_perception = perception_with_handle(frame, "table_0")
     assert HasBinaryProperty(cookie_perception, GAZED_AT) in frame.property_assertions
     assert HasBinaryProperty(dad_perception, GAZED_AT) in frame.property_assertions
@@ -639,7 +639,7 @@ def test_gaze_specified():
     )
     frame = perception.frames[0]
     cookie_perception = perception_with_handle(frame, "cookie_0")
-    dad_perception = perception_with_handle(frame, "person_0")
+    dad_perception = perception_with_handle(frame, "dad_0")
     table_perception = perception_with_handle(frame, "table_0")
     # only the cookie is gazed at, because the user said so.
     assert HasBinaryProperty(cookie_perception, GAZED_AT) in frame.property_assertions


### PR DESCRIPTION
This seemed like the simplest point to intervene in the process of creating an `ObjectPerception` to ensure that its `debug_handle` corresponds with the particular type of human involved. (Mom, Dad, Baby). 

For context, the visualization system relies on the debug_handle strings of `ObjectPerception`s (strictly speaking, not information given to any learner) in order do things that depend on the object's type such as loading the correct geometry for the object type, or scaling it according to its type, etc. In the case of people (see #603) `ObjectPerceptions` for particular sorts of people have their debug_handles set to their supertype: Person. 

I can add some explanatory comments before merging, but I wanted to check if this overall is in _bad idea_ territory. 