### PR TITLE
Translating subject (speaker) as "I" when using HAS

### DIFF
--- a/adam/language_specific/english/english_language_generator.py
+++ b/adam/language_specific/english/english_language_generator.py
@@ -233,12 +233,18 @@ class SimpleRuleBasedEnglishLanguageGenerator(
             if IS_SPEAKER in _object.properties:
                 if syntactic_role_if_known == NOMINAL_SUBJECT:
                     noun_lexicon_entry = I
-                elif any(relation for relation in self.situation.always_relations if
-                         (relation.relation_type == HAS and
-                          any(property_ in relation.first_slot.properties
-                              for property_ in [IS_SPEAKER]) and
-                          len(self.situation.actions) == 0)
-                         ):
+                elif any(
+                    relation
+                    for relation in self.situation.always_relations
+                    if (
+                        relation.relation_type == HAS
+                        and any(
+                            property_ in relation.first_slot.properties
+                            for property_ in [IS_SPEAKER]
+                        )
+                        and len(self.situation.actions) == 0
+                    )
+                ):
                     noun_lexicon_entry = I
                 else:
                     noun_lexicon_entry = ME

--- a/adam/language_specific/english/english_language_generator.py
+++ b/adam/language_specific/english/english_language_generator.py
@@ -242,7 +242,7 @@ class SimpleRuleBasedEnglishLanguageGenerator(
                             property_ in relation.first_slot.properties
                             for property_ in [IS_SPEAKER]
                         )
-                        and len(self.situation.actions) == 0
+                        and not self.situation.actions
                     )
                 ):
                     noun_lexicon_entry = I

--- a/adam/language_specific/english/english_language_generator.py
+++ b/adam/language_specific/english/english_language_generator.py
@@ -228,11 +228,17 @@ class SimpleRuleBasedEnglishLanguageGenerator(
                     f"an ontology node currently: {_object}"
                 )
             # TODO: we don't currently translate modifiers of nouns.
-            # Issue: https://github.com/isi-vista/adam/issues/58
 
             # Check if the situation object is the speaker
             if IS_SPEAKER in _object.properties:
                 if syntactic_role_if_known == NOMINAL_SUBJECT:
+                    noun_lexicon_entry = I
+                elif any(relation for relation in self.situation.always_relations if
+                         (relation.relation_type == HAS and
+                          any(property_ in relation.first_slot.properties
+                              for property_ in [IS_SPEAKER]) and
+                          len(self.situation.actions) == 0)
+                         ):
                     noun_lexicon_entry = I
                 else:
                     noun_lexicon_entry = ME

--- a/adam/language_specific/english/english_language_generator.py
+++ b/adam/language_specific/english/english_language_generator.py
@@ -227,12 +227,16 @@ class SimpleRuleBasedEnglishLanguageGenerator(
                     f"Don't know how to handle objects which don't correspond to "
                     f"an ontology node currently: {_object}"
                 )
-            # TODO: we don't currently translate modifiers of nouns.
 
             # Check if the situation object is the speaker
             if IS_SPEAKER in _object.properties:
                 if syntactic_role_if_known == NOMINAL_SUBJECT:
                     noun_lexicon_entry = I
+                # For when HAS (which is a RELATION) is the verb and the speaker is the subject.
+                # (This Special case is needed because HAS is a RELATION and not an ACTION in the
+                # ontology, so HAS is never recognized as the NOMINAL_SUBJECT as this
+                # determination normally occurs in translate_action_to_verb(), which only
+                # processes ACTIONs)
                 elif any(
                     relation
                     for relation in self.situation.always_relations

--- a/tests/language_specific/english/test_english_language_generator.py
+++ b/tests/language_specific/english/test_english_language_generator.py
@@ -454,6 +454,7 @@ def test_i_put_a_cookie_in_dads_box_using_my_as_mom_speaker():
         _SIMPLE_GENERATOR.generate_language(situation, FixedIndexChooser(0))
     ).as_token_sequence() == ("I", "put", "a", "cookie", "in", "Dad", "'s", "box")
 
+
 def test_i_have_my_ball():
     baby = situation_object(BABY, properties=[IS_SPEAKER])
     ball = situation_object(BALL)

--- a/tests/language_specific/english/test_english_language_generator.py
+++ b/tests/language_specific/english/test_english_language_generator.py
@@ -454,6 +454,19 @@ def test_i_put_a_cookie_in_dads_box_using_my_as_mom_speaker():
         _SIMPLE_GENERATOR.generate_language(situation, FixedIndexChooser(0))
     ).as_token_sequence() == ("I", "put", "a", "cookie", "in", "Dad", "'s", "box")
 
+def test_i_have_my_ball():
+    baby = situation_object(BABY, properties=[IS_SPEAKER])
+    ball = situation_object(BALL)
+    situation = HighLevelSemanticsSituation(
+        ontology=GAILA_PHASE_1_ONTOLOGY,
+        salient_objects=[baby, ball],
+        always_relations=[Relation(HAS, baby, ball)],
+    )
+
+    assert only(
+        _SIMPLE_GENERATOR.generate_language(situation, FixedIndexChooser(0))
+    ).as_token_sequence() == ("I", "have", "my", "ball")
+
 
 def test_dad_has_a_cookie():
     dad = situation_object(DAD)


### PR DESCRIPTION
Closes #605 
My attempt at this task:
I think this has to do with `HAS` being a `RELATION` and not an `ACTION` even though it is a verb. As such, the speaker is never recognized as the `NOMINAL_SUBJECT`, resulting in the default `ME` being used.
I added a special case in noun_for_object() in the english_language_generator:
This seems to fix it, and I don't see any obvious cases where it affects the other parts:
```
# Check if the situation object is the speaker
            if IS_SPEAKER in _object.properties:
                if syntactic_role_if_known == NOMINAL_SUBJECT:
                    noun_lexicon_entry = I
                elif any(
                    relation
                    for relation in self.situation.always_relations
                    if (
                        relation.relation_type == HAS
                        and any(
                            property_ in relation.first_slot.properties
                            for property_ in [IS_SPEAKER]
                        )
                        and len(self.situation.actions) == 0
                    )
                ):
                else:
                    noun_lexicon_entry = ME
```
NOTE: I only added the elif case

With this, all the test cases containing a `HAS` relation in test_english_language_generator pass including a test I added:
```
def test_i_have_my_ball():
    baby = situation_object(BABY, properties=[IS_SPEAKER])
    ball = situation_object(BALL)
    situation = HighLevelSemanticsSituation(
        ontology=GAILA_PHASE_1_ONTOLOGY,
        salient_objects=[baby, ball],
        always_relations=[Relation(HAS, baby, ball)],
    )

    assert only(
        _SIMPLE_GENERATOR.generate_language(situation, FixedIndexChooser(0))
    ).as_token_sequence() == ("I", "have", "my", "ball")
```

What do you think?