### PR TITLE
Alteration to the process of freezing action goal to include non-movi…

### DIFF
--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -56,6 +56,7 @@ from adam.perception.developmental_primitive_perception import (
     Relation,
 )
 from adam.ontology import OntologyNode
+from adam.ontology.phase1_ontology import AGENT, THEME, GOAL
 from adam.relation import IN_REGION
 from adam.situation import SituationObject
 
@@ -647,12 +648,12 @@ def objects_to_freeze(
         theme: Optional[SituationObject] = None
         goal: Optional[Union[SituationObject, Region[SituationObject]]] = None
         for (ontology_node, object_or_region) in action.argument_roles_to_fillers.items():
-
-            if ontology_node.handle == "goal":
+            print(ontology_node)
+            if ontology_node == GOAL:
                 goal = object_or_region
-            elif ontology_node.handle == "agent":
+            elif ontology_node == AGENT:
                 agent = object_or_region
-            elif ontology_node.handle == "theme":
+            elif ontology_node == THEME:
                 theme = object_or_region
     if goal and isinstance(goal, Region):
         # the SituationObjects are always present if there is a verb that calls for them, so we want to see

--- a/adam/visualization/make_scenes.py
+++ b/adam/visualization/make_scenes.py
@@ -56,7 +56,6 @@ from adam.perception.developmental_primitive_perception import (
     Relation,
 )
 from adam.ontology import OntologyNode
-from adam.ontology.phase1_ontology import GO
 from adam.relation import IN_REGION
 from adam.situation import SituationObject
 

--- a/tests/visualization/positioning_test.py
+++ b/tests/visualization/positioning_test.py
@@ -199,7 +199,7 @@ def test_in_region_constraint() -> None:
 
     in_region_relations = {box: [region]}
 
-    in_region_penalty = InRegionPenalty(obj_percept_to_aabb, {}, in_region_relations)
+    in_region_penalty = InRegionPenalty(obj_percept_to_aabb, {}, {}, in_region_relations)
 
     box_penalty = in_region_penalty(box, immutableset([region]))
     assert box_penalty > 0
@@ -221,7 +221,7 @@ def test_in_region_constraint() -> None:
 
     in_region_relations = {box2: [region]}
 
-    in_region_penalty = InRegionPenalty(obj_percept_to_aabb, {}, in_region_relations)
+    in_region_penalty = InRegionPenalty(obj_percept_to_aabb, {}, {}, in_region_relations)
 
     box_penalty = in_region_penalty(box2, immutableset([region]))
 


### PR DESCRIPTION
…ng action agent / theme. Changed PositioningModel to facilitate this better.

Will need to check if this generalizes well to additional action types. 

Closes #646 

Example queued up with curriculum selection is:

Throwing + PP. In the first frame, all objects are parameters, the object to be thrown is in the region of the person's hand. In the second frame, the person and the goal object for the throw are stationary, only the thrown object is repositioned. 
