### PR TITLE
Disable "go to" for phase 1

### DIFF
--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -1922,16 +1922,17 @@ def _make_go_with_prepositions(num_samples: int = 5, *, noise_objects: int = 0):
         "Go + PP",
         chain(
             # To
-            flatten(
-                [
-                    sampled(
-                        _go_to_template(agent, goal_object, background),
-                        ontology=GAILA_PHASE_1_ONTOLOGY,
-                        chooser=PHASE1_CHOOSER_FACTORY(),
-                        max_to_sample=num_samples,
-                    )
-                ]
-            ),
+            # Disabled - See https://github.com/isi-vista/adam/issues/569
+            # flatten(
+            #    [
+            #        sampled(
+            #            _go_to_template(agent, goal_object, background),
+            #            ontology=GAILA_PHASE_1_ONTOLOGY,
+            #            chooser=PHASE1_CHOOSER_FACTORY(),
+            #            max_to_sample=num_samples,
+            #        )
+            #    ]
+            # ),
             # In
             flatten(
                 [


### PR DESCRIPTION
As referenced: https://github.com/isi-vista/adam/issues/569#issuecomment-600213478 disabling "go to" for phase 1 verb curriculum as it's functionally identical to "go (near)"