### PR TITLE
Fix miscellaneous semantics 

### DIFF
--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -1414,7 +1414,6 @@ def make_jump_template(
     agent: TemplateObjectVariable,
     *,
     use_adverbial_path_modifier: bool,
-    operator: PathOperator = None,
     spatial_properties: Iterable[OntologyNode] = immutableset(),
     background: Iterable[TemplateObjectVariable] = immutableset(),
 ) -> Phase1SituationTemplate:
@@ -1434,7 +1433,9 @@ def make_jump_template(
                         (
                             agent,
                             SpatialPath(
-                                operator=operator,
+                                operator=AWAY_FROM
+                                if use_adverbial_path_modifier
+                                else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
                                 properties=spatial_properties,
                             ),
@@ -1541,7 +1542,6 @@ def _make_jump_curriculum(
                         make_jump_template(
                             jumper,
                             use_adverbial_path_modifier=use_adverbial_path_modifier,
-                            operator=operator,
                             background=background,
                         ),
                         ontology=GAILA_PHASE_1_ONTOLOGY,
@@ -1549,7 +1549,6 @@ def _make_jump_curriculum(
                         max_to_sample=num_samples if num_samples else 25,
                     )
                     for use_adverbial_path_modifier in (True, False)
-                    for operator in [TOWARD, AWAY_FROM]
                 ]
             ),
             flatten(

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -1414,6 +1414,7 @@ def make_jump_template(
     agent: TemplateObjectVariable,
     *,
     use_adverbial_path_modifier: bool,
+    operator: PathOperator = None,
     spatial_properties: Iterable[OntologyNode] = immutableset(),
     background: Iterable[TemplateObjectVariable] = immutableset(),
 ) -> Phase1SituationTemplate:
@@ -1433,7 +1434,7 @@ def make_jump_template(
                         (
                             agent,
                             SpatialPath(
-                                operator=AWAY_FROM
+                                operator=operator
                                 if use_adverbial_path_modifier
                                 else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
@@ -1549,6 +1550,7 @@ def _make_jump_curriculum(
                         max_to_sample=num_samples if num_samples else 25,
                     )
                     for use_adverbial_path_modifier in (True, False)
+                    for operator in [TOWARD, AWAY_FROM]
                 ]
             ),
             flatten(
@@ -1978,7 +1980,9 @@ def make_walk_run_template(
                         (
                             agent,
                             SpatialPath(
-                                operator=operator,
+                                operator=operator
+                                if use_adverbial_path_modifier
+                                else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
                                 properties=spatial_properties,
                             ),

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -111,6 +111,7 @@ from adam.ontology.phase1_ontology import (
     BALL,
     WALK,
     strictly_over,
+    strictly_under,
 )
 from adam.ontology.phase1_spatial_relations import (
     AWAY_FROM,
@@ -950,21 +951,19 @@ def _make_object_under_or_over_object_curriculum(
 ) -> Phase1InstanceGroup:
     object_under = standard_object("object_0")
     object_above = standard_object("object_1", required_properties=[HAS_SPACE_UNDER])
-    bird = object_variable("bird_0", BIRD)
-    object_under_bird = standard_object("object_under_bird_0")
 
     templates = [
         Phase1SituationTemplate(
             f"object-under-object",
             salient_object_variables=[object_above, object_under],
             constraining_relations=[bigger_than(object_above, object_under)],
-            asserted_always_relations=[strictly_over(object_above, object_under)],
+            asserted_always_relations=[strictly_under(object_above, object_under)],
             background_object_variables=make_noise_objects(noise_objects),
         ),
         Phase1SituationTemplate(
             f"object-over-object",
-            salient_object_variables=[object_under_bird, bird],
-            asserted_always_relations=[strictly_over(bird, object_under_bird)],
+            salient_object_variables=[object_under, object_above],
+            asserted_always_relations=[strictly_over(object_under, object_above)],
             background_object_variables=make_noise_objects(noise_objects),
         ),
     ]
@@ -1482,7 +1481,9 @@ def make_pass_template(
                         (
                             agent,
                             SpatialPath(
-                                operator=operator,
+                                operator=operator
+                                if use_adverbial_path_modifier
+                                else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
                                 properties=spatial_properties,
                             ),
@@ -2387,7 +2388,9 @@ def make_push_templates(
                         (
                             agent,
                             SpatialPath(
-                                operator=operator,
+                                operator=operator
+                                if use_adverbial_path_modifier
+                                else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
                                 properties=spatial_properties,
                             ),
@@ -2437,7 +2440,7 @@ def _make_push_curriculum(
                     ),
                     push_goal=standard_object("push_goal", INANIMATE_OBJECT),
                     use_adverbial_path_modifier=adverbial_path_modifier,
-                    operator=operator,
+                    operator=operator if adverbial_path_modifier else None,
                     background=make_noise_objects(noise_objects),
                 )
             ]

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -957,13 +957,13 @@ def _make_object_under_or_over_object_curriculum(
             f"object-under-object",
             salient_object_variables=[object_above, object_under],
             constraining_relations=[bigger_than(object_above, object_under)],
-            asserted_always_relations=[strictly_under(object_above, object_under)],
+            asserted_always_relations=[strictly_under(object_under, object_above)],
             background_object_variables=make_noise_objects(noise_objects),
         ),
         Phase1SituationTemplate(
             f"object-over-object",
             salient_object_variables=[object_under, object_above],
-            asserted_always_relations=[strictly_over(object_under, object_above)],
+            asserted_always_relations=[strictly_over(object_above, object_under)],
             background_object_variables=make_noise_objects(noise_objects),
         ),
     ]

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -1922,8 +1922,11 @@ def make_take_template(
                                 # this is a hack since "grab" with an adverb doesn't really work in English
                                 operator=operator
                                 if (
-                                    not spatial_properties
-                                    or HARD_FORCE not in spatial_properties
+                                    use_adverbial_path_modifier
+                                    and (
+                                        not spatial_properties
+                                        or HARD_FORCE not in spatial_properties
+                                    )
                                 )
                                 else None,
                                 reference_object=ground,
@@ -2342,7 +2345,9 @@ def make_push_templates(
                         (
                             agent,
                             SpatialPath(
-                                operator=operator,
+                                operator=operator
+                                if use_adverbial_path_modifier
+                                else None,
                                 reference_object=GROUND_OBJECT_TEMPLATE,
                                 properties=spatial_properties,
                             ),

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -1784,7 +1784,10 @@ def make_sit_templates(noise_objects: Optional[int]) -> Iterable[Phase1Situation
     )
 
     sit_surface = standard_object(
-        "surface", THING, required_properties=[CAN_HAVE_THINGS_RESTING_ON_THEM]
+        "surface",
+        THING,
+        required_properties=[CAN_HAVE_THINGS_RESTING_ON_THEM],
+        banned_properties=[GROUND],
     )
     seat = standard_object(
         "sitting-surface", INANIMATE_OBJECT, required_properties=[CAN_BE_SAT_ON_BY_PEOPLE]

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -2883,7 +2883,10 @@ def _make_sit_with_prepositions(
 ) -> Phase1InstanceGroup:
     agent = standard_object("agent", THING, required_properties=[ANIMATE])
     seat = standard_object(
-        "seat", INANIMATE_OBJECT, required_properties=[CAN_BE_SAT_ON_BY_PEOPLE]
+        "seat",
+        INANIMATE_OBJECT,
+        required_properties=[CAN_BE_SAT_ON_BY_PEOPLE],
+        banned_properties=[GROUND],
     )
     seat_in = standard_object("seat_in", INANIMATE_OBJECT, required_properties=[HOLLOW])
     surface = standard_object(

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -273,7 +273,6 @@ def curriculum_from_params(
             None,
         ),
         "m13-shuffled": (build_m13_shuffled_curriculum, build_gaila_m13_curriculum),
-        "m13-relations": (build_gaila_phase1_relation_curriculum, None),
     }
 
     curriculum_name = params.string("curriculum", str_to_train_test_curriculum.keys())

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -273,6 +273,7 @@ def curriculum_from_params(
             None,
         ),
         "m13-shuffled": (build_m13_shuffled_curriculum, build_gaila_m13_curriculum),
+        "m13-relations": (build_gaila_phase1_relation_curriculum, None),
     }
 
     curriculum_name = params.string("curriculum", str_to_train_test_curriculum.keys())

--- a/adam/ontology/phase1_ontology.py
+++ b/adam/ontology/phase1_ontology.py
@@ -2440,12 +2440,6 @@ def _make_jump_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
                     )
                 ],
             ),
-            # during=DuringAction(
-            #    objects_to_paths=[
-            #        (jump_agent, SpatialPath(AWAY_FROM, JUMP_INITIAL_SUPPORTER_AUX)),
-            #        (jump_agent, SpatialPath(AWAY_FROM, jump_ground)),
-            #    ]
-            # ),
             asserted_properties=asserted_properties,
         ),
     )

--- a/adam/ontology/phase1_ontology.py
+++ b/adam/ontology/phase1_ontology.py
@@ -2171,12 +2171,13 @@ def _make_throw_descriptions() -> Iterable[Tuple[OntologyNode, ActionDescription
     ]
     preconditions = [
         has(_THROW_AGENT, _THROW_THEME),
-        # contacts(_THROW_MANIPULATOR, _THROW_THEME),
+        on(_THROW_THEME, _THROW_AGENT),
         contacts(_THROW_AGENT, _THROW_THEME),
     ]
     postconditions = flatten_relations(
         [
             Relation(IN_REGION, _THROW_THEME, THROW_GOAL),
+            on(_THROW_THEME, THROW_GOAL),
             # negate(contacts(_THROW_MANIPULATOR, _THROW_THEME)),
             negate(contacts(_THROW_AGENT, _THROW_THEME)),
         ]
@@ -2412,16 +2413,7 @@ def _make_jump_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
     jump_goal = ActionDescriptionVariable(THING)
     jump_ground = ActionDescriptionVariable(GROUND)
 
-    preconditions = (
-        [
-            Relation(
-                IN_REGION,
-                jump_agent,
-                Region(JUMP_INITIAL_SUPPORTER_AUX, distance=EXTERIOR_BUT_IN_CONTACT),
-            )
-        ],
-    )
-
+    preconditions = preconditions = [on(jump_agent, JUMP_INITIAL_SUPPORTER_AUX)]
     asserted_properties = [(jump_agent, VOLITIONALLY_INVOLVED), (jump_agent, MOVES)]
 
     # bare jump
@@ -2434,8 +2426,26 @@ def _make_jump_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
                 objects_to_paths=[
                     (jump_agent, SpatialPath(AWAY_FROM, JUMP_INITIAL_SUPPORTER_AUX)),
                     (jump_agent, SpatialPath(AWAY_FROM, jump_ground)),
-                ]
+                ],
+                # must be above the ground at some point during the action
+                at_some_point=[
+                    Relation(
+                        IN_REGION,
+                        jump_agent,
+                        Region(
+                            reference_object=JUMP_INITIAL_SUPPORTER_AUX,
+                            distance=DISTAL,
+                            direction=GRAVITATIONAL_UP,
+                        ),
+                    )
+                ],
             ),
+            # during=DuringAction(
+            #    objects_to_paths=[
+            #        (jump_agent, SpatialPath(AWAY_FROM, JUMP_INITIAL_SUPPORTER_AUX)),
+            #        (jump_agent, SpatialPath(AWAY_FROM, jump_ground)),
+            #    ]
+            # ),
             asserted_properties=asserted_properties,
         ),
     )
@@ -2450,10 +2460,21 @@ def _make_jump_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
                 objects_to_paths=[
                     (jump_agent, SpatialPath(AWAY_FROM, JUMP_INITIAL_SUPPORTER_AUX)),
                     (jump_agent, SpatialPath(AWAY_FROM, jump_ground)),
-                    (jump_agent, SpatialPath(TO, jump_goal)),
-                ]
+                ],
+                # must be above the ground at some point during the action
+                at_some_point=[
+                    Relation(
+                        IN_REGION,
+                        jump_agent,
+                        Region(
+                            reference_object=JUMP_INITIAL_SUPPORTER_AUX,
+                            distance=DISTAL,
+                            direction=GRAVITATIONAL_UP,
+                        ),
+                    )
+                ],
             ),
-            postconditions=[Relation(IN_REGION, jump_agent, jump_goal)],
+            postconditions=[on(jump_agent, jump_goal)],
             asserted_properties=asserted_properties,
         ),
     )
@@ -2488,8 +2509,8 @@ def _make_roll_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
         ROLL,
         ActionDescription(
             frame=ActionDescriptionFrame({AGENT: roll_agent, THEME: roll_theme}),
+            enduring_conditions=[on(roll_theme, ROLL_SURFACE_AUXILIARY)],
             during=DuringAction(
-                continuously=[on(roll_theme, ROLL_SURFACE_AUXILIARY)],
                 objects_to_paths=[
                     (
                         roll_theme,
@@ -2500,7 +2521,7 @@ def _make_roll_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
                             orientation_changed=True,
                         ),
                     )
-                ],
+                ]
             ),
             preconditions=[contacts(roll_agent, roll_theme)],
             asserted_properties=[
@@ -2517,8 +2538,8 @@ def _make_roll_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
         ROLL,
         ActionDescription(
             frame=ActionDescriptionFrame({AGENT: roll_agent}),
+            enduring_conditions=[on(roll_agent, ROLL_SURFACE_AUXILIARY)],
             during=DuringAction(
-                continuously=[on(roll_agent, ROLL_SURFACE_AUXILIARY)],
                 objects_to_paths=[
                     (
                         roll_agent,
@@ -2529,7 +2550,7 @@ def _make_roll_description() -> Iterable[Tuple[OntologyNode, ActionDescription]]
                             orientation_changed=True,
                         ),
                     )
-                ],
+                ]
             ),
             asserted_properties=[(roll_agent, MOVES)],
         ),
@@ -2541,19 +2562,15 @@ _FLY_GROUND = ActionDescriptionVariable(GROUND)
 
 _FLY_ACTION_DESCRIPTION = ActionDescription(
     frame=ActionDescriptionFrame({AGENT: _FLY_AGENT}),
-    during=DuringAction(
-        continuously=[
-            Relation(
-                IN_REGION,
-                _FLY_AGENT,
-                Region(
-                    reference_object=_FLY_GROUND,
-                    distance=DISTAL,
-                    direction=GRAVITATIONAL_UP,
-                ),
-            )
-        ]
-    ),
+    enduring_conditions=[
+        Relation(
+            IN_REGION,
+            _FLY_AGENT,
+            Region(
+                reference_object=_FLY_GROUND, distance=DISTAL, direction=GRAVITATIONAL_UP
+            ),
+        )
+    ],
     asserted_properties=[(_FLY_AGENT, VOLITIONALLY_INVOLVED), (_FLY_AGENT, MOVES)],
 )
 

--- a/adam/ontology/phase1_ontology.py
+++ b/adam/ontology/phase1_ontology.py
@@ -2488,7 +2488,8 @@ WALK_SURFACE_AUXILIARY = ActionDescriptionVariable(
 )
 _WALK_ACTION_DESCRIPTION = ActionDescription(
     frame=ActionDescriptionFrame({AGENT: _WALK_AGENT}),
-    during=DuringAction(continuously=[on(_WALK_AGENT, WALK_SURFACE_AUXILIARY)]),
+    enduring_conditions=[on(_WALK_AGENT, WALK_SURFACE_AUXILIARY)],
+    # during=DuringAction(continuously=[on(_WALK_AGENT, WALK_SURFACE_AUXILIARY)]),
     asserted_properties=[(_WALK_AGENT, MOVES)],
 )
 

--- a/adam/ontology/phase1_ontology.py
+++ b/adam/ontology/phase1_ontology.py
@@ -2112,10 +2112,8 @@ def _make_drink_description() -> Iterable[Tuple[OntologyNode, ActionDescription]
         DRINK,
         ActionDescription(
             frame=ActionDescriptionFrame({AGENT: drink_agent, THEME: drink_theme}),
-            preconditions=[
-                inside(drink_theme, DRINK_CONTAINER_AUX),
-                bigger_than(drink_agent, DRINK_CONTAINER_AUX),
-            ],
+            preconditions=[inside(drink_theme, DRINK_CONTAINER_AUX)],
+            enduring_conditions=[bigger_than(drink_agent, DRINK_CONTAINER_AUX)],
             postconditions=[inside(drink_theme, drink_agent)],
             asserted_properties=[
                 (drink_agent, VOLITIONALLY_INVOLVED),

--- a/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
+++ b/adam/perception/high_level_semantics_situation_to_developmental_primitive_perception.py
@@ -263,7 +263,6 @@ class _PerceptionGeneration:
                     axis_info=axis_info,
                 )
             )
-
         # finally, if there are actions, we perceive the before and after states of the action
         _action_perception = self._perceive_action()
         # sometimes additional before and after relations will be given explicitly by the user
@@ -275,7 +274,6 @@ class _PerceptionGeneration:
             self._perceive_relation(relation)
             for relation in self._situation.after_action_relations
         ]
-
         # Add ground for always perception if needed
         if self._include_ground:
             # Grabbing any "always" ground relations
@@ -287,6 +285,12 @@ class _PerceptionGeneration:
                         _action_perception.before_relations,
                         explicit_after_relations,
                         _action_perception.after_relations,
+                        _action_perception.during_action.at_some_point
+                        if _action_perception.during_action
+                        else {},
+                        _action_perception.during_action.continuously
+                        if _action_perception.during_action
+                        else {},
                     )
                 )
             )
@@ -789,7 +793,6 @@ class _PerceptionGeneration:
         for situation_object in self._situation.all_objects:
             if situation_object.ontology_node != GROUND:
                 object_perception = self._objects_to_perceptions[situation_object]
-
                 add_on_ground = True
 
                 if object_perception in objects_to_relations:


### PR DESCRIPTION
Fixes the following: 

- keep rolling object on rolling surface
- make sure that the thrown object isn't necessarily always on the ground before and after
- make sure that a flying this isn't on the ground 
- add distinguishing between "jump" and "jump up" 
- add distinguishing between "run" and "run down" and "walk" and "walk down"
- the cup when drinking should be the same size throughout the action 
- learn both "over" and "under" (TODO: currently both of these have both objects on the ground #929 )