### PR TITLE
Debugging to run entire M13 without crashing

### DIFF
--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -2853,12 +2853,6 @@ def make_throw_templates(
         required_properties=[ANIMATE],
         banned_properties=[IS_SPEAKER, IS_ADDRESSEE],
     )
-    catcher = standard_object(
-        "catcher_0",
-        THING,
-        required_properties=[ANIMATE],
-        banned_properties=[IS_SPEAKER, IS_ADDRESSEE],
-    )
 
     object_thrown = standard_object("object_0", required_properties=[INANIMATE])
     implicit_goal_reference = standard_object(
@@ -2867,7 +2861,7 @@ def make_throw_templates(
     background = make_noise_objects(noise_objects)
 
     return [
-        # Dad throws a cookie on the ground
+        # # Dad throws a cookie on the ground
         throw_on_ground_template(thrower, object_thrown, background=background),
         # A baby throws a truck
         throw_template(
@@ -2890,7 +2884,7 @@ def make_throw_templates(
             background=background,
         ),
         # Throw To
-        throw_to_template(thrower, object_thrown, catcher, background=background),
+        # throw_to_template(thrower, object_thrown, catcher, background=background),
     ]
 
 
@@ -3312,28 +3306,28 @@ def build_gaila_phase1_verb_curriculum(
     One particular instantiation of the object-learning parts of the curriculum for GAILA Phase 1.
     """
     return [
-        _make_fall_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_transfer_of_possession_curriculum(
-            num_samples, num_noise_objects, language_generator
-        ),
-        _make_fly_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_roll_curriculum(num_samples, num_noise_objects, language_generator),
-        # TODO: see https://github.com/isi-vista/adam/issues/937
-        # _make_speaker_addressee_curriculum(
+        # _make_fall_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_transfer_of_possession_curriculum(
         #     num_samples, num_noise_objects, language_generator
         # ),
-        _make_jump_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_drink_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_sit_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_put_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_eat_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_take_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_move_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_spin_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_go_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_push_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_fly_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_roll_curriculum(num_samples, num_noise_objects, language_generator),
+        # # TODO: see https://github.com/isi-vista/adam/issues/937
+        # # _make_speaker_addressee_curriculum(
+        # #     num_samples, num_noise_objects, language_generator
+        # # ),
+        # _make_jump_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_drink_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_sit_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_put_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_eat_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_take_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_move_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_spin_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_go_curriculum(num_samples, num_noise_objects, language_generator),
+        # _make_push_curriculum(num_samples, num_noise_objects, language_generator),
         # TODO: fix this based on Deniz's thoughts
-        # _make_throw_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_throw_curriculum(num_samples, num_noise_objects, language_generator),
         _make_pass_curriculum(num_samples, num_noise_objects, language_generator),
         # _make_put_on_speaker_addressee_body_part_curriculum(num_samples, num_noise_objects, language_generator),
         _make_come_curriculum(num_samples, num_noise_objects, language_generator),

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -3332,7 +3332,8 @@ def build_gaila_phase1_verb_curriculum(
         _make_spin_curriculum(num_samples, num_noise_objects, language_generator),
         _make_go_curriculum(num_samples, num_noise_objects, language_generator),
         _make_push_curriculum(num_samples, num_noise_objects, language_generator),
-        _make_throw_curriculum(num_samples, num_noise_objects, language_generator),
+        # TODO: fix this based on Deniz's thoughts
+        # _make_throw_curriculum(num_samples, num_noise_objects, language_generator),
         _make_pass_curriculum(num_samples, num_noise_objects, language_generator),
         # _make_put_on_speaker_addressee_body_part_curriculum(num_samples, num_noise_objects, language_generator),
         _make_come_curriculum(num_samples, num_noise_objects, language_generator),

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -2861,8 +2861,8 @@ def make_throw_templates(
     background = make_noise_objects(noise_objects)
 
     return [
-        # # Dad throws a cookie on the ground
-        throw_on_ground_template(thrower, object_thrown, background=background),
+        # # Dad throws a cookie on the ground -- disabled because we learn this in verbs with dynamic prepositions
+        # throw_on_ground_template(thrower, object_thrown, background=background),
         # A baby throws a truck
         throw_template(
             thrower, object_thrown, implicit_goal_reference, background=background
@@ -2883,7 +2883,7 @@ def make_throw_templates(
             is_up=False,
             background=background,
         ),
-        # Throw To
+        # Throw To -- disabled because we learn this in verbs with dynamic prepositions
         # throw_to_template(thrower, object_thrown, catcher, background=background),
     ]
 
@@ -3306,26 +3306,26 @@ def build_gaila_phase1_verb_curriculum(
     One particular instantiation of the object-learning parts of the curriculum for GAILA Phase 1.
     """
     return [
-        # _make_fall_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_transfer_of_possession_curriculum(
+        _make_fall_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_transfer_of_possession_curriculum(
+            num_samples, num_noise_objects, language_generator
+        ),
+        _make_fly_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_roll_curriculum(num_samples, num_noise_objects, language_generator),
+        # TODO: see https://github.com/isi-vista/adam/issues/937
+        # _make_speaker_addressee_curriculum(
         #     num_samples, num_noise_objects, language_generator
         # ),
-        # _make_fly_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_roll_curriculum(num_samples, num_noise_objects, language_generator),
-        # # TODO: see https://github.com/isi-vista/adam/issues/937
-        # # _make_speaker_addressee_curriculum(
-        # #     num_samples, num_noise_objects, language_generator
-        # # ),
-        # _make_jump_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_drink_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_sit_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_put_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_eat_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_take_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_move_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_spin_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_go_curriculum(num_samples, num_noise_objects, language_generator),
-        # _make_push_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_jump_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_drink_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_sit_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_put_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_eat_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_take_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_move_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_spin_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_go_curriculum(num_samples, num_noise_objects, language_generator),
+        _make_push_curriculum(num_samples, num_noise_objects, language_generator),
         # TODO: fix this based on Deniz's thoughts
         _make_throw_curriculum(num_samples, num_noise_objects, language_generator),
         _make_pass_curriculum(num_samples, num_noise_objects, language_generator),

--- a/adam/curriculum/phase1_curriculum.py
+++ b/adam/curriculum/phase1_curriculum.py
@@ -3318,9 +3318,9 @@ def build_gaila_phase1_verb_curriculum(
         ),
         _make_fly_curriculum(num_samples, num_noise_objects, language_generator),
         _make_roll_curriculum(num_samples, num_noise_objects, language_generator),
-        # TODO: in Chinese, _make_speaker_addressee_curriculum currently leads to an error in graph matching
+        # TODO: see https://github.com/isi-vista/adam/issues/937
         # _make_speaker_addressee_curriculum(
-        #    num_samples, num_noise_objects, language_generator
+        #     num_samples, num_noise_objects, language_generator
         # ),
         _make_jump_curriculum(num_samples, num_noise_objects, language_generator),
         _make_drink_curriculum(num_samples, num_noise_objects, language_generator),

--- a/adam/curriculum/phase2_curriculum.py
+++ b/adam/curriculum/phase2_curriculum.py
@@ -331,9 +331,6 @@ def build_gaila_m13_curriculum(
             build_gaila_phase1_object_curriculum(
                 num_samples, num_noise_objects, language_generator
             ),
-            build_gaila_plurals_curriculum(
-                num_samples, num_noise_objects, language_generator
-            ),
             build_gaila_phase1_attribute_curriculum(
                 num_samples, num_noise_objects, language_generator
             ),
@@ -363,6 +360,9 @@ def build_gaila_m13_curriculum(
                 )
             ),
             build_functionally_defined_objects_curriculum(
+                num_samples, num_noise_objects, language_generator
+            ),
+            build_gaila_plurals_curriculum(
                 num_samples, num_noise_objects, language_generator
             ),
         )

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -37,7 +37,6 @@ from adam.ontology.phase1_ontology import (
     CAN_BE_SAT_ON_BY_PEOPLE,
     HAS_SPACE_UNDER,
     PUSH,
-    TO,
     THEME,
     PUSH_SURFACE_AUX,
     ANIMATE,
@@ -722,9 +721,10 @@ def _throw_to_template(
                             theme,
                             SpatialPath(
                                 TO,
-                                reference_object=Region(
-                                    goal_reference, distance=PROXIMAL
+                                reference_source_object=Region(
+                                    goal_reference, distance=DISTAL
                                 ),
+                                reference_destination_object=goal_reference,
                             ),
                         )
                     ]
@@ -796,7 +796,16 @@ def _throw_on_template(
                         (
                             theme,
                             SpatialPath(
-                                None, reference_object=goal_reference, properties=[]
+                                None,
+                                reference_source_object=Region(
+                                    goal_reference, distance=DISTAL
+                                ),
+                                reference_destination_object=Region(
+                                    goal_reference,
+                                    direction=GRAVITATIONAL_UP,
+                                    distance=EXTERIOR_BUT_IN_CONTACT,
+                                ),
+                                properties=[],
                             ),
                         )
                     ]

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -108,6 +108,7 @@ from adam.situation.templates.phase1_templates import (
 
 BOOL_SET = immutableset([True, False])
 
+# THIS IS A TEST
 # TODO: fix https://github.com/isi-vista/adam/issues/917 which causes us to have to specify that we don't wish to include ME_HACK and YOU_HACK in our curriculum design
 # PUSH templates
 

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -37,7 +37,6 @@ from adam.ontology.phase1_ontology import (
     CAN_BE_SAT_ON_BY_PEOPLE,
     HAS_SPACE_UNDER,
     PUSH,
-    TO,
     THEME,
     PUSH_SURFACE_AUX,
     ANIMATE,

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -37,6 +37,7 @@ from adam.ontology.phase1_ontology import (
     CAN_BE_SAT_ON_BY_PEOPLE,
     HAS_SPACE_UNDER,
     PUSH,
+    TO,
     THEME,
     PUSH_SURFACE_AUX,
     ANIMATE,
@@ -715,6 +716,19 @@ def _throw_to_template(
                     (THEME, theme),
                     (GOAL, Region(goal_reference, distance=PROXIMAL)),
                 ],
+                during=DuringAction(
+                    objects_to_paths=[
+                        (
+                            theme,
+                            SpatialPath(
+                                TO,
+                                reference_object=Region(
+                                    goal_reference, distance=PROXIMAL
+                                ),
+                            ),
+                        )
+                    ]
+                ),
             )
         ],
         after_action_relations=[near(theme, goal_reference)],
@@ -777,6 +791,16 @@ def _throw_on_template(
                         ),
                     ),
                 ],
+                during=DuringAction(
+                    objects_to_paths=[
+                        (
+                            theme,
+                            SpatialPath(
+                                None, reference_object=goal_reference, properties=[]
+                            ),
+                        )
+                    ]
+                ),
             )
         ],
         after_action_relations=[on(theme, goal_reference)],

--- a/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
+++ b/adam/curriculum/verbs_with_dynamic_prepositions_curriculum.py
@@ -108,7 +108,6 @@ from adam.situation.templates.phase1_templates import (
 
 BOOL_SET = immutableset([True, False])
 
-# THIS IS A TEST
 # TODO: fix https://github.com/isi-vista/adam/issues/917 which causes us to have to specify that we don't wish to include ME_HACK and YOU_HACK in our curriculum design
 # PUSH templates
 

--- a/adam/language_specific/chinese/chinese_language_generator.py
+++ b/adam/language_specific/chinese/chinese_language_generator.py
@@ -521,15 +521,13 @@ class SimpleRuleBasedChineseLanguageGenerator(
                 reference_object_node = self._noun_for_object(
                     spatial_path.reference_source_object
                 )
-            if self.dependency_graph.out_degree[reference_object_node]:
-                return None
-            else:
-                self.dependency_graph.add_edge(
-                    DependencyTreeToken(preposition, ADPOSITION),
-                    reference_object_node,
-                    role=CASE_SPATIAL,
-                )
-                return (OBLIQUE_NOMINAL, reference_object_node)
+
+            self.dependency_graph.add_edge(
+                DependencyTreeToken(preposition, ADPOSITION),
+                reference_object_node,
+                role=CASE_SPATIAL,
+            )
+            return (OBLIQUE_NOMINAL, reference_object_node)
 
         def _translate_relation_to_action_modifier(
             self,

--- a/adam/learner/alignments.py
+++ b/adam/learner/alignments.py
@@ -166,7 +166,6 @@ class LanguageConceptAlignment:
                     #    f"that filler to tokens. Known alignments are: "
                     #    f"{self.node_to_language_span}"
                     # )
-
             covered_token_span = surface_template.match_against_tokens(
                 self.language.as_token_sequence(),
                 slots_to_filler_spans=immutabledict(slots_to_spans),

--- a/adam/learner/surface_templates.py
+++ b/adam/learner/surface_templates.py
@@ -120,6 +120,7 @@ class SurfaceTemplate:
                             slot_filler_span.start : slot_filler_span.end
                         ]
                     )
+                # if there's a slot without a filler, we just don't learn from this instance instead of raising a runtime error
                 else:
                     return None
                     # raise RuntimeError(

--- a/adam/learner/template_learner.py
+++ b/adam/learner/template_learner.py
@@ -304,6 +304,7 @@ class AbstractTemplateLearnerNew(TemplateLearner, ABC):
         ) = self._enrich_common(
             language_perception_semantic_alignment.perception_semantic_alignment
         )
+        # we try to learn from the given instance
         return LanguagePerceptionSemanticAlignment(
             # We need to link the things we found to the language
             # so later learning stages can (a) know they are already covered

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -3734,6 +3734,7 @@ def test_invalid_relations():
         generated_tokens(situation)
 
 
+
 def test_drink_from():
     agent = situation_object(MOM)
     liquid = situation_object(WATER)
@@ -3813,3 +3814,4 @@ def test_order_ba_and_prep_phrase():
         "twei1",
         "sya4 lai2",
     )
+

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -3734,7 +3734,6 @@ def test_invalid_relations():
         generated_tokens(situation)
 
 
-
 def test_drink_from():
     agent = situation_object(MOM)
     liquid = situation_object(WATER)
@@ -3816,7 +3815,6 @@ def test_order_ba_and_prep_phrase():
     )
 
 
-
 def test_move_should_have_dao():
     agent = situation_object(MOM)
     goal = situation_object(BOOK)
@@ -3866,7 +3864,6 @@ def test_move_should_have_dao_away():
                                 reference_destination_object=Region(
                                     goal, distance=DISTAL
                                 ),
-
                                 reference_axis=HorizontalAxisOfObject(agent, 1),
                             ),
                         )

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -3734,7 +3734,6 @@ def test_invalid_relations():
         generated_tokens(situation)
 
 
-
 def test_drink_from():
     agent = situation_object(MOM)
     liquid = situation_object(WATER)
@@ -3815,3 +3814,62 @@ def test_order_ba_and_prep_phrase():
         "sya4 lai2",
     )
 
+
+def test_move_should_have_dao():
+    agent = situation_object(MOM)
+    goal = situation_object(BOOK)
+    situation = HighLevelSemanticsSituation(
+        ontology=GAILA_PHASE_1_ONTOLOGY,
+        salient_objects=[agent, goal],
+        actions=[
+            Action(
+                MOVE,
+                argument_roles_to_fillers=[(AGENT, agent), (GOAL, goal)],
+                during=DuringAction(
+                    objects_to_paths=[
+                        (
+                            agent,
+                            SpatialPath(
+                                operator=TOWARD,
+                                reference_source_object=Region(goal, distance=DISTAL),
+                                reference_destination_object=goal,
+                                reference_axis=HorizontalAxisOfObject(agent, 1),
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
+    assert generated_tokens(situation) == ("ma1 ma1", "chau2", "shu1", "yi2 dung4")
+
+
+def test_move_should_have_dao_away():
+    agent = situation_object(MOM)
+    goal = situation_object(BOOK)
+    situation = HighLevelSemanticsSituation(
+        ontology=GAILA_PHASE_1_ONTOLOGY,
+        salient_objects=[agent, goal],
+        actions=[
+            Action(
+                MOVE,
+                argument_roles_to_fillers=[(AGENT, agent), (GOAL, goal)],
+                during=DuringAction(
+                    objects_to_paths=[
+                        (
+                            agent,
+                            SpatialPath(
+                                operator=AWAY_FROM,
+                                reference_source_object=goal,
+                                reference_destination_object=Region(
+                                    goal, distance=DISTAL
+                                ),
+                                reference_axis=HorizontalAxisOfObject(agent, 1),
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
+    assert generated_tokens(situation) == ("ma1 ma1", "li2", "shu1", "yi2 dung4")


### PR DESCRIPTION
can run `run_m13` without encountering an error in English and Chinese now with `m13.params`

For `log_experiment` with `m13_complete`, our issue in English is "throw", since we have two possible "throw-to" templates; one indicates goal and one indicates recipient. For English, we express both with "to" but in Chinese we can distinguish since there is a different coverb indicating person goal ("gei")