### PR TITLE
Fix indexing and add accuracy logging 

### DIFF
--- a/adam/experiment/__init__.py
+++ b/adam/experiment/__init__.py
@@ -138,6 +138,11 @@ def execute_experiment(
     Runs an `Experiment`.
     """
 
+    # the starting point must be greater than or equal to 0
+    if starting_point < 0:
+        logging.warning(f"Starting point {starting_point} is invalid, setting to 0")
+        starting_point = 0
+
     # make the directories in which to log the learner
     if log_learner_state and learner_logging_path:
         learner_path = learner_logging_path / "learner_state"

--- a/adam/experiment/__init__.py
+++ b/adam/experiment/__init__.py
@@ -249,7 +249,7 @@ def execute_experiment(
 
             learner.observe(
                 LearningExample(perceptual_representation, linguistic_description),
-                observation_num=num_observations,
+                offset=starting_point,
             )
 
             if experiment.post_example_training_observers:

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -125,7 +125,7 @@ def log_experiment_entry_point(params: Parameters) -> None:
         ),
         log_learner_state=params.boolean("log_learner_state", default=True),
         learner_logging_path=params.optional_creatable_directory("experiment_group_dir"),
-        starting_point=params.integer("starting_point", default=-1),
+        starting_point=params.integer("starting_point", default=0),
         point_to_log=params.integer("point_to_log", default=0),
         load_learner_state=params.optional_existing_file("learner_state_path"),
     )

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -112,7 +112,7 @@ def log_experiment_entry_point(params: Parameters) -> None:
             ),
             pre_example_training_observers=[
                 logger.pre_observer(),
-                CandidateAccuracyObserver("pre-acc-observer"),
+                CandidateAccuracyObserver("pre-acc-observer", accuracy_to_txt=True),
             ],
             post_example_training_observers=[logger.post_observer()],
             test_instance_groups=test_instance_groups,

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -103,6 +103,10 @@ def log_experiment_entry_point(params: Parameters) -> None:
         params, language_mode
     )
 
+    # these are the params to use for writing accuracy to a text file at every iteration (e.g. to graph later)
+    accuracy_to_txt = params.boolean("accuracy_to_txt", default=False)
+    txt_path = params.string("accuracy_logging_path", default="out.txt")
+
     execute_experiment(
         Experiment(
             name=experiment_name,
@@ -112,7 +116,9 @@ def log_experiment_entry_point(params: Parameters) -> None:
             ),
             pre_example_training_observers=[
                 logger.pre_observer(),
-                CandidateAccuracyObserver("pre-acc-observer", accuracy_to_txt=True),
+                CandidateAccuracyObserver(
+                    "pre-acc-observer", accuracy_to_txt=accuracy_to_txt, txt_path=txt_path
+                ),
             ],
             post_example_training_observers=[logger.post_observer()],
             test_instance_groups=test_instance_groups,

--- a/adam/experiment/log_experiment.py
+++ b/adam/experiment/log_experiment.py
@@ -105,7 +105,15 @@ def log_experiment_entry_point(params: Parameters) -> None:
 
     # these are the params to use for writing accuracy to a text file at every iteration (e.g. to graph later)
     accuracy_to_txt = params.boolean("accuracy_to_txt", default=False)
-    txt_path = params.string("accuracy_logging_path", default="out.txt")
+    accuracy_logging_path = params.string(
+        "accuracy_logging_path", default="accuracy_out.txt"
+    )
+    # we want to log to the same file as the html output, etc.
+    experiment_group_dir = params.optional_creatable_directory("experiment_group_dir")
+    if experiment_group_dir:
+        txt_path = str(experiment_group_dir / accuracy_logging_path)
+    else:
+        txt_path = accuracy_logging_path
 
     execute_experiment(
         Experiment(
@@ -130,7 +138,7 @@ def log_experiment_entry_point(params: Parameters) -> None:
             "log_hypothesis_every_n_steps", default=250
         ),
         log_learner_state=params.boolean("log_learner_state", default=True),
-        learner_logging_path=params.optional_creatable_directory("experiment_group_dir"),
+        learner_logging_path=experiment_group_dir,
         starting_point=params.integer("starting_point", default=0),
         point_to_log=params.integer("point_to_log", default=0),
         load_learner_state=params.optional_existing_file("learner_state_path"),

--- a/adam/experiment/observer.py
+++ b/adam/experiment/observer.py
@@ -101,6 +101,11 @@ class CandidateAccuracyObserver(
     Provide an accuracy score.
     """
     name: str = attrib(validator=instance_of(str))
+
+    # these params allow the accuracy to be written out to a text file at each step which is helpful for graphing for
+    # experiments such as the gaze ablation where we want to compare accuracy
+    accuracy_to_txt: bool = attrib(default=False)
+    txt_path: str = attrib(validator=instance_of(str), default="out.txt")
     _num_predictions: int = attrib(init=False, default=0)
     _num_predictions_with_gold_in_candidates: int = attrib(init=False, default=0)
 
@@ -122,6 +127,18 @@ class CandidateAccuracyObserver(
 
     def report(self) -> None:
         accuracy = self.accuracy()
+
+        # write out to an accuracy file if requested to do so by the user
+        if self.accuracy_to_txt:
+            try:
+                with open(self.txt_path, "a") as f:
+                    f.write(f"{accuracy}\n")
+            # we currently catch errors with a warning rather than stopping the program if we can't log accuracy
+            except OSError as e:
+                logging.warning(
+                    f"The following error occurred while attempting to log accuracy to a txt file: {e}"
+                )
+
         if accuracy is not None:
             logging.info(
                 "%s: accuracy of learner's predictions ('gold' description was in learner's candidates) "

--- a/adam/experiment/observer.py
+++ b/adam/experiment/observer.py
@@ -105,7 +105,7 @@ class CandidateAccuracyObserver(
     # these params allow the accuracy to be written out to a text file at each step which is helpful for graphing for
     # experiments such as the gaze ablation where we want to compare accuracy
     accuracy_to_txt: bool = attrib(default=False)
-    txt_path: str = attrib(validator=instance_of(str), default="out.txt")
+    txt_path: str = attrib(validator=instance_of(str), default="accuracy_out.txt")
     _num_predictions: int = attrib(init=False, default=0)
     _num_predictions_with_gold_in_candidates: int = attrib(init=False, default=0)
 

--- a/adam/learner/__init__.py
+++ b/adam/learner/__init__.py
@@ -88,7 +88,7 @@ class TopLevelLanguageLearner(ABC, Generic[PerceptionT, LinguisticDescriptionT])
     def observe(
         self,
         learning_example: LearningExample[PerceptionT, LinguisticDescription],
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
         """
         Observe a `LearningExample`, possibly updating internal state.
@@ -139,7 +139,7 @@ class MemorizingLanguageLearner(
     def observe(
         self,
         learning_example: LearningExample[PerceptionT, LinguisticDescription],
-        observation_num: int = -1,  # pylint:disable=unused-argument
+        offset: int = 0,  # pylint:disable=unused-argument
     ) -> None:
         self._memorized_situations[
             learning_example.perception
@@ -211,7 +211,7 @@ class ComposableLearner(ABC):
     def learn_from(
         self,
         language_perception_semantic_alignment: LanguagePerceptionSemanticAlignment,
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
         """
         Learn from a `LanguagePerceptionSemanticAlignment` describing a situation. This may update

--- a/adam/learner/functional_learner.py
+++ b/adam/learner/functional_learner.py
@@ -74,20 +74,14 @@ class FunctionalLearner(TemplateLearner):
     def learn_from(
         self,
         language_perception_semantic_alignment: LanguagePerceptionSemanticAlignment,
-        observation_num: int = -1,
+        offset: int = 0,
     ):
-        if observation_num >= 0:
-            logging.info(
-                "Observation %s: %s",
-                observation_num,
-                language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
-            )
-        else:
-            logging.info(
-                "Observation %s: %s",
-                self._observation_num,
-                language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
-            )
+
+        logging.info(
+            "Observation %s: %s",
+            self._observation_num + offset,
+            language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
+        )
 
         self._observation_num += 1
 

--- a/adam/learner/integrated_learner.py
+++ b/adam/learner/integrated_learner.py
@@ -40,7 +40,7 @@ class LanguageLearnerNew:
         learning_example: LearningExample[
             DevelopmentalPrimitivePerceptionFrame, LinguisticDescription
         ],
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
         pass
 
@@ -82,20 +82,14 @@ class IntegratedTemplateLearner(
         learning_example: LearningExample[
             DevelopmentalPrimitivePerceptionFrame, LinguisticDescription
         ],
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
-        if observation_num >= 0:
-            logging.info(
-                "Observation %s: %s",
-                observation_num,
-                learning_example.linguistic_description.as_token_string(),
-            )
-        else:
-            logging.info(
-                "Observation %s: %s",
-                self._observation_num,
-                learning_example.linguistic_description.as_token_string(),
-            )
+
+        logging.info(
+            "Observation %s: %s",
+            self._observation_num + offset,
+            learning_example.linguistic_description.as_token_string(),
+        )
 
         self._observation_num += 1
 
@@ -128,9 +122,7 @@ class IntegratedTemplateLearner(
                 # perception graph edge wrappers.
                 # See https://github.com/isi-vista/adam/issues/792 .
                 if not learning_example.perception.is_dynamic():
-                    sub_learner.learn_from(
-                        current_learner_state, observation_num=observation_num
-                    )
+                    sub_learner.learn_from(current_learner_state, offset=offset)
                 current_learner_state = sub_learner.enrich_during_learning(
                     current_learner_state
                 )
@@ -141,9 +133,7 @@ class IntegratedTemplateLearner(
             )
 
             if self.functional_learner:
-                self.functional_learner.learn_from(
-                    current_learner_state, observation_num=observation_num
-                )
+                self.functional_learner.learn_from(current_learner_state, offset=offset)
 
     def describe(
         self, perception: PerceptualRepresentation[DevelopmentalPrimitivePerceptionFrame]

--- a/adam/learner/objects.py
+++ b/adam/learner/objects.py
@@ -542,7 +542,7 @@ class ObjectRecognizerAsTemplateLearner(TemplateLearner):
     def learn_from(
         self,
         language_perception_semantic_alignment: LanguagePerceptionSemanticAlignment,
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
         # The object recognizer doesn't learn anything.
         # It just recognizes predefined object patterns.

--- a/adam/learner/template_learner.py
+++ b/adam/learner/template_learner.py
@@ -63,20 +63,14 @@ class AbstractTemplateLearner(
         learning_example: LearningExample[
             DevelopmentalPrimitivePerceptionFrame, LinguisticDescription
         ],
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
-        if observation_num >= 0:
-            logging.info(
-                "Observation %s: %s",
-                observation_num,
-                learning_example.linguistic_description.as_token_string(),
-            )
-        else:
-            logging.info(
-                "Observation %s: %s",
-                self._observation_num,
-                learning_example.linguistic_description.as_token_string(),
-            )
+
+        logging.info(
+            "Observation %s: %s",
+            self._observation_num + offset,
+            learning_example.linguistic_description.as_token_string(),
+        )
         self._observation_num += 1
 
         self._assert_valid_input(learning_example)
@@ -274,20 +268,13 @@ class AbstractTemplateLearnerNew(TemplateLearner, ABC):
     def learn_from(
         self,
         language_perception_semantic_alignment: LanguagePerceptionSemanticAlignment,
-        observation_num: int = -1,
+        offset: int = 0,
     ) -> None:
-        if observation_num >= 0:
-            logging.info(
-                "Observation %s: %s",
-                observation_num,
-                language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
-            )
-        else:
-            logging.info(
-                "Observation %s: %s",
-                self._observation_num,
-                language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
-            )
+        logging.info(
+            "Observation %s: %s",
+            self._observation_num + offset,
+            language_perception_semantic_alignment.language_concept_alignment.language.as_token_string(),
+        )
 
         self._observation_num += 1
 

--- a/parameters/experiments/m13/m13.debug.params
+++ b/parameters/experiments/m13/m13.debug.params
@@ -15,3 +15,5 @@ include_m9_complete: False
 include_m13_complete: False
 include_m13_shuffled: False
 include_debug: True
+accuracy_to_txt : True
+accuracy_logging_path : "accuracy_logging_out.txt"

--- a/parameters/experiments/m13/pursuit_with_noisy_gaze.params
+++ b/parameters/experiments/m13/pursuit_with_noisy_gaze.params
@@ -5,6 +5,10 @@ _includes:
 experiment: 'pursuit-ablating-gaze'
 curriculum: pursuit
 learner: pursuit-gaze
+
+accuracy_to_txt : True
+accuracy_logging_path : "out_out.txt"
+
 pursuit:
    learning_factor: 0.05
    graph_match_confirmation_threshold: 0.7

--- a/parameters/experiments/m13/pursuit_with_noisy_gaze.params
+++ b/parameters/experiments/m13/pursuit_with_noisy_gaze.params
@@ -6,7 +6,6 @@ experiment: 'pursuit-ablating-gaze'
 curriculum: pursuit
 learner: pursuit-gaze
 accuracy_to_txt : True
-accuracy_logging_path : "out_out.txt"
 
 pursuit:
    learning_factor: 0.05

--- a/parameters/experiments/m13/pursuit_with_noisy_gaze.params
+++ b/parameters/experiments/m13/pursuit_with_noisy_gaze.params
@@ -5,7 +5,6 @@ _includes:
 experiment: 'pursuit-ablating-gaze'
 curriculum: pursuit
 learner: pursuit-gaze
-starting_point : 17
 accuracy_to_txt : True
 accuracy_logging_path : "out_out.txt"
 

--- a/parameters/experiments/m13/pursuit_with_noisy_gaze.params
+++ b/parameters/experiments/m13/pursuit_with_noisy_gaze.params
@@ -5,7 +5,7 @@ _includes:
 experiment: 'pursuit-ablating-gaze'
 curriculum: pursuit
 learner: pursuit-gaze
-
+starting_point : 17
 accuracy_to_txt : True
 accuracy_logging_path : "out_out.txt"
 


### PR DESCRIPTION
This fixes the issue that our HTML file was beginning indexing at -1; it and the logging now start at 0 

It also adds an optional way of logging accuracy at each iteration of the experiment to create graphs like the ones shown [here](https://www.dropbox.com/scl/fi/n1bgnqr3v4tj35lz0mzw2/Gaze-Ablation-in-Pursuit-Object-Learning.paper?dl=0&rlkey=rijevp5ei2y5orjwodednnr2g).