### PR TITLE
Yi classifiers

### DIFF
--- a/adam/language_specific/chinese/chinese_language_generator.py
+++ b/adam/language_specific/chinese/chinese_language_generator.py
@@ -1030,7 +1030,7 @@ class SimpleRuleBasedChineseLanguageGenerator(
                     IGNORE_HAS_AS_VERB not in self.situation.syntax_hints
                     and not self.situation.is_dynamic
                 ):
-                    return
+                    pass
                     # TODO: we currently return here since we can't handle one possessive node and one not for the third person (i.e. I have my ball, you have your ball
                     # but right now, we just have "Dad has a ball" since otherwise we'll end up adding "de" (equivalent of 's in English) to both instances (e.g. Dad's has Dad's ball)
                     # since the nodes aren't unique). https://github.com/isi-vista/adam/issues/55
@@ -1206,6 +1206,7 @@ class SimpleRuleBasedChineseLanguageGenerator(
 
             # get a noun for the second object and add it to the tree
             if isinstance(relation.second_slot, SituationObject):
+                print("IS OBJECT")
                 second_slot_dependency_node = self._noun_for_object(relation.second_slot)
             elif isinstance(relation.second_slot, Region):
                 second_slot_dependency_node = self._noun_for_object(

--- a/tests/curriculum/phase1_curriculum_test.py
+++ b/tests/curriculum/phase1_curriculum_test.py
@@ -101,7 +101,7 @@ def test_objects_with_colors_is_curriculum(language_generator):
             and c[1].as_token_sequence()[2] == "is"
         ) or (
             language_generator == GAILA_PHASE_1_CHINESE_LANGUAGE_GENERATOR
-            and c[1].as_token_sequence()[1] == "shr4"
+            and c[1].as_token_sequence()[3] == "shr4"
         )
     curriculum_test(
         _make_objects_with_colors_is_curriculum(None, None, language_generator)

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -201,7 +201,7 @@ def test_common_noun():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY, salient_objects=[situation_object(BALL)]
     )
-    assert generated_tokens(situation) == ("chyou2",)
+    assert generated_tokens(situation) == ("yi1", "ge4", "chyou2")
 
 
 # a single mass noun. The distinction isn't nearly as salient in Chinese
@@ -246,7 +246,7 @@ def test_green_ball():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY, salient_objects=[ball]
     )
-    assert generated_tokens(situation) == ("lyu4 se4", "chyou2")
+    assert generated_tokens(situation) == ("yi1", "ge4", "lyu4 se4", "chyou2")
 
 
 # possession for NP's: first person
@@ -259,7 +259,7 @@ def test_my_green_ball():
         always_relations=[Relation(HAS, dad, ball)],
         syntax_hints=[IGNORE_HAS_AS_VERB],
     )
-    assert generated_tokens(situation) == ("wo3 de", "lyu4 se4", "chyou2")
+    assert generated_tokens(situation) == ("wo3 de", "yi1", "ge4", "lyu4 se4", "chyou2")
 
 
 # possession for NP's: second person
@@ -272,7 +272,7 @@ def test_your_green_ball():
         always_relations=[Relation(HAS, dad, ball)],
         syntax_hints=[IGNORE_HAS_AS_VERB],
     )
-    assert generated_tokens(situation) == ("ni3 de", "lyu4 se4", "chyou2")
+    assert generated_tokens(situation) == ("ni3 de", "yi1", "ge4", "lyu4 se4", "chyou2")
 
 
 # possession for NP's: third person
@@ -285,7 +285,14 @@ def test_babade_green_ball():
         always_relations=[Relation(HAS, dad, ball)],
         syntax_hints=[IGNORE_HAS_AS_VERB],
     )
-    assert generated_tokens(situation) == ("ba4 ba4", "de", "lyu4 se4", "chyou2")
+    assert generated_tokens(situation) == (
+        "ba4 ba4",
+        "de",
+        "yi1",
+        "ge4",
+        "lyu4 se4",
+        "chyou2",
+    )
 
 
 """COUNTING NOUN PHRASE TESTS (WITH CLASSIFIERS) -- CHECKED BY NATIVE SPEAKER"""
@@ -297,7 +304,7 @@ def test_single_item():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY, salient_objects=[dog]
     )
-    assert generated_tokens(situation) == ("gou3",)
+    assert generated_tokens(situation) == ("yi1", "jr1", "gou3")
 
 
 # two objects, which can be counted distinctly
@@ -376,13 +383,13 @@ def test_house_classifier():
 
 
 # test the classifier for cups of liquid
-def test_cups_of_liquid():
+def test_no_classifiers_for_mass_nouns():
     water1 = situation_object(WATER, debug_handle="water1")
     water2 = situation_object(WATER, debug_handle="water2")
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY, salient_objects=[water1, water2]
     )
-    assert generated_tokens(situation) == ("lyang3", "bei1", "shwei3")
+    assert generated_tokens(situation) == ("shwei3",)
 
 
 # test the classifier for chairs
@@ -444,7 +451,7 @@ def test_one_salient_object():
     situation = HighLevelSemanticsSituation(
         ontology=GAILA_PHASE_1_ONTOLOGY, salient_objects=[truck1], other_objects=[truck2]
     )
-    assert generated_tokens(situation) == ("ka3 che1",)
+    assert generated_tokens(situation) == ("yi1", "lyang4", "ka3 che1")
 
 
 # many objects, only two are salient
@@ -500,6 +507,8 @@ def test_noun_with_spatial_modifier():
         "di4 myan4",
         "shang4",
         "de",
+        "yi1",
+        "jang1",
         "jwo1 dz",
     )
 
@@ -528,6 +537,8 @@ def test_two_objects_with_mum_no_extra():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "jr1",
         "nyau3",
         "pang2 byan1",
         "de",
@@ -561,6 +572,8 @@ def test_two_objects_with_mum():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "jr1",
         "nyau3",
         "pang2 byan1",
         "de",
@@ -587,6 +600,8 @@ def test_mum_under_object():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "jr1",
         "nyau3",
         "sya4 myan4",
         "de",
@@ -611,6 +626,8 @@ def test_mum_above_object():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "jr1",
         "nyau3",
         "shang4 myan4",
         "de",
@@ -643,9 +660,13 @@ def test_object_beside_object():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "pang2 byan1",
         "de",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 
@@ -692,9 +713,13 @@ def test_object_behind_in_front_object():
     )
     assert generated_tokens(front_situation) == (
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "chyan2 myan4",
         "de",
+        "yi1",
+        "ge4",
         "syang1 dz",
     )
 
@@ -732,9 +757,13 @@ def test_object_behind_in_front_object():
     )
     assert generated_tokens(behind_situation) == (
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "hou4 myan4",
         "de",
+        "yi1",
+        "ge4",
         "syang1 dz",
     )
 
@@ -750,7 +779,7 @@ def test_falling():
         salient_objects=[ball],
         actions=[Action(FALL, argument_roles_to_fillers=[(THEME, ball)])],
     )
-    assert generated_tokens(situation) == ("chyou2", "dye2 dau3")
+    assert generated_tokens(situation) == ("yi1", "ge4", "chyou2", "dye2 dau3")
 
 
 # test the simple subject-verb phrase "mum eats"
@@ -777,7 +806,13 @@ def test_simple_SVO():
             )
         ],
     )
-    assert generated_tokens(situation) == ("ma1 ma1", "chr1", "chyu1 chi2 bing3")
+    assert generated_tokens(situation) == (
+        "ma1 ma1",
+        "chr1",
+        "yi1",
+        "kwai4",
+        "chyu1 chi2 bing3",
+    )
 
 
 # test SVIO transfer of possession
@@ -799,7 +834,11 @@ def test_simple_SVIO_transfer():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "gei3",
+        "yi1",
+        "ge4",
         "bau3 bau3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
     )
 
@@ -844,7 +883,14 @@ def test_simple_SVIO_transfer_with_personal_pronouns():
         ],
         syntax_hints=[PREFER_DITRANSITIVE],
     )
-    assert generated_tokens(situation) == ("wo3", "gei3", "ni3", "chyu1 chi2 bing3")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "gei3",
+        "ni3",
+        "yi1",
+        "kwai4",
+        "chyu1 chi2 bing3",
+    )
 
 
 # test SVIO transfer of possession with personal pronouns
@@ -865,6 +911,8 @@ def test_simple_SVIO_transfer_with_personal_pronouns_and_ba():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "gei3",
         "ni3",
@@ -884,7 +932,7 @@ def test_simple_SVO_movement():
             )
         ],
     )
-    assert generated_tokens(situation) == ("ba4 ba4", "twei1", "yi3 dz")
+    assert generated_tokens(situation) == ("ba4 ba4", "twei1", "yi1", "ba3", "yi3 dz")
 
 
 # SVIO with pronouns
@@ -907,6 +955,8 @@ def test_you_give_me_a_cookie():
         "ni3",
         "gei3",
         "wo3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
     )
 
@@ -944,9 +994,13 @@ def test_mom_put_a_ball_on_a_table_zai():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -983,9 +1037,13 @@ def test_mom_put_a_ball_on_a_table_dao():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dau4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1021,9 +1079,13 @@ def test_I_put_a_ball_on_a_table_zai():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1059,9 +1121,13 @@ def test_i_put_a_ball_on_a_table_dao():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dau4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1097,9 +1163,13 @@ def test_you_put_a_ball_on_a_table_zai():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1135,9 +1205,13 @@ def test_you_put_a_ball_on_a_table_dao():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "fang4",
         "dau4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1165,9 +1239,13 @@ def test_dad_put_a_cookie_in_a_box_zai():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1197,9 +1275,13 @@ def test_dad_put_a_cookie_in_a_box_dao():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dau4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1227,9 +1309,13 @@ def test_i_put_cookie_in_box_zai():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1257,9 +1343,13 @@ def test_you_put_cookie_in_box_zai():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1283,11 +1373,17 @@ def test_take_to_car():
     )
 
     assert generated_tokens(situation) == (
+        "yi1",
+        "ge4",
         "bau3 bau3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "na2",
         "dau4",
+        "yi1",
+        "lyang4",
         "chi4 che1",
         "shang4",
     )
@@ -1318,10 +1414,14 @@ def test_i_put_cookie_in_my_box():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
         "wo3 de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1351,10 +1451,14 @@ def test_i_put_cookie_in_my_box_dao():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dau4",
         "wo3 de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1383,9 +1487,13 @@ def test_third_person_cookie_in_his_box():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1414,10 +1522,14 @@ def test_you_put_cookie_in_your_box():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
         "ni3 de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1447,10 +1559,14 @@ def test_speaker_owner_of_box():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
         "wo3 de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1480,10 +1596,14 @@ def test_addressee_owner_of_box():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
         "ni3 de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1513,11 +1633,15 @@ def test_speaker_not_owner_of_box():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "fang4",
         "dzai4",
         "ba4 ba4",
         "de",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "li3",
     )
@@ -1535,10 +1659,18 @@ def test_i_have_my_ball():
         always_relations=[Relation(HAS, baby, ball)],
         actions=[],
     )
-    assert generated_tokens(situation) == ("wo3", "you3", "wo3 de", "chyou2")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "you3",
+        "wo3 de",
+        "yi1",
+        "ge4",
+        "chyou2",
+    )
 
 
 # this tests possession when a non-speaker has something that they possess
+# TODO: fix this
 def test_dad_has_cookie():
     dad = situation_object(DAD)
     cookie = situation_object(COOKIE)
@@ -1546,7 +1678,7 @@ def test_dad_has_cookie():
         ontology=GAILA_PHASE_1_ONTOLOGY,
         salient_objects=[dad, cookie],
         always_relations=[Relation(HAS, dad, cookie)],
-        # actions=[],
+        actions=[],
     )
     assert generated_tokens(situation) == ("ba4 ba4", "you3", "chyu1 chi2 bing3")
 
@@ -1561,7 +1693,14 @@ def test_you_have_your_ball():
         always_relations=[Relation(HAS, baby, ball)],
         actions=[],
     )
-    assert generated_tokens(situation) == ("ni3", "you3", "ni3 de", "chyou2")
+    assert generated_tokens(situation) == (
+        "ni3",
+        "you3",
+        "ni3 de",
+        "yi1",
+        "ge4",
+        "chyou2",
+    )
 
 
 """PATH MODIFIERS -- CHECKED BY NATIVE SPEAKER"""
@@ -1596,9 +1735,20 @@ def test_path_modifier():
             )
         ],
     )
-    assert generated_tokens(situation) == ("nyau3", "fei1", "gwo4", "wu1", "shang4 myan4")
+    assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
+        "nyau3",
+        "fei1",
+        "gwo4",
+        "yi1",
+        "jyan1",
+        "wu1",
+        "shang4 myan4",
+    )
 
 
+# TODO: fix this
 # a slightly different test for over
 def test_jumps_over():
     dad = situation_object(DAD)
@@ -1620,6 +1770,8 @@ def test_jumps_over():
         "ba4 ba4",
         "tyau4",
         "gwo4",
+        "yi1",
+        "ba3",
         "yi3 dz",
         "shang4 myan4",
     )
@@ -1662,9 +1814,13 @@ def test_path_modifier_under():
         ],
     )
     assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
         "nyau3",
         "fei1",
         "dau4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "sya4 myan4",
     )
@@ -1684,9 +1840,13 @@ def test_path_modifier_on():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
         "gwun3",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -1670,7 +1670,6 @@ def test_i_have_my_ball():
 
 
 # this tests possession when a non-speaker has something that they possess
-# TODO: fix this
 def test_dad_has_cookie():
     dad = situation_object(DAD)
     cookie = situation_object(COOKIE)
@@ -1680,7 +1679,13 @@ def test_dad_has_cookie():
         always_relations=[Relation(HAS, dad, cookie)],
         actions=[],
     )
-    assert generated_tokens(situation) == ("ba4 ba4", "you3", "chyu1 chi2 bing3")
+    assert generated_tokens(situation) == (
+        "ba4 ba4",
+        "you3",
+        "yi1",
+        "kwai4",
+        "chyu1 chi2 bing3",
+    )
 
 
 # this tests possession where the addressee has something that they possess
@@ -1748,7 +1753,6 @@ def test_path_modifier():
     )
 
 
-# TODO: fix this
 # a slightly different test for over
 def test_jumps_over():
     dad = situation_object(DAD)
@@ -2388,16 +2392,15 @@ def test_to_regions_as_goal_come():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation_come(Region(goal_object, distance=PROXIMAL), goal_object)
-    ) == ("yi1", "jr1", "gou3", "lai2", "syang1 dz")
+    ) == ("yi1", "jr1", "gou3", "lai2", "yi1", "ge4", "syang1 dz")
 
 
-# TODO: fix this
 # this tests being inside a region
 def test_in_region_as_goal_come():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation_come(Region(goal_object, distance=INTERIOR), goal_object)
-    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "syang1 dz", "li3")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "ge4", "syang1 dz", "li3")
 
 
 # this tests being next to a region
@@ -2464,7 +2467,7 @@ def test_over_region_as_goal_come():
             Region(goal_object, distance=PROXIMAL, direction=GRAVITATIONAL_UP),
             goal_object,
         )
-    ) == ("gou3", "lai2", "dau4", "jwo1 dz", "shang4 myan4")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "jang1", "jwo1 dz", "shang4 myan4")
 
 
 # this tests going under a region
@@ -2476,7 +2479,7 @@ def test_under_region_as_goal_come():
             Region(goal_object, distance=PROXIMAL, direction=GRAVITATIONAL_DOWN),
             goal_object,
         )
-    ) == ("gou3", "lai2", "dau4", "jwo1 dz", "sya4 myan4")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "jang1", "jwo1 dz", "sya4 myan4")
 
 
 """MISC TESTS REPLICATED FROM ENGLISH TESTING FILE -- CHECKED BY NATIVE SPEAKER"""
@@ -2500,11 +2503,17 @@ def test_roll():
         always_relations=[on(theme, surface)],
     )
     assert generated_tokens(situation) == (
+        "yi1",
+        "ge4",
         "bau3 bau3",
         "dzai4",
+        "yi1",
+        "ge4",
         "syang1 dz",
         "shang4",
         "gwun3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
     )
 
@@ -2519,7 +2528,7 @@ def test_the_ball_is_green():
         salient_objects=[ball],
         syntax_hints=[ATTRIBUTES_AS_X_IS_Y],
     )
-    assert generated_tokens(situation) == ("chyou2", "shr4", "lyu4 se4")
+    assert generated_tokens(situation) == ("yi1", "ge4", "chyou2", "shr4", "lyu4 se4")
 
 
 # x_is_y with first person possession
@@ -2532,7 +2541,14 @@ def test_my_ball_is_green():
         always_relations=[Relation(HAS, dad, ball)],
         syntax_hints=[IGNORE_HAS_AS_VERB, ATTRIBUTES_AS_X_IS_Y],
     )
-    assert generated_tokens(situation) == ("wo3 de", "chyou2", "shr4", "lyu4 se4")
+    assert generated_tokens(situation) == (
+        "wo3 de",
+        "yi1",
+        "ge4",
+        "chyou2",
+        "shr4",
+        "lyu4 se4",
+    )
 
 
 # x_is_y with second person possession
@@ -2545,7 +2561,14 @@ def test_your_ball_is_red():
         always_relations=[Relation(HAS, dad, ball)],
         syntax_hints=[IGNORE_HAS_AS_VERB, ATTRIBUTES_AS_X_IS_Y],
     )
-    assert generated_tokens(situation) == ("ni3 de", "chyou2", "shr4", "hung2 se4")
+    assert generated_tokens(situation) == (
+        "ni3 de",
+        "yi1",
+        "ge4",
+        "chyou2",
+        "shr4",
+        "hung2 se4",
+    )
 
 
 # x_is_y for classifier sentence
@@ -2583,7 +2606,7 @@ def test_my_watermelon():
         always_relations=[Relation(HAS, baby, watermelon)],
         syntax_hints=[IGNORE_HAS_AS_VERB],
     )
-    assert generated_tokens(situation) == ("wo3 de", "syi1 gwa1")
+    assert generated_tokens(situation) == ("wo3 de", "yi1", "ge4", "syi1 gwa1")
 
 
 # testing of towards/away from
@@ -2616,6 +2639,8 @@ def test_dad_moves_towards_cookie():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "chau2",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "yi2 dung4",
     )
@@ -2652,6 +2677,8 @@ def test_dad_moves_away_from_cookie():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "li2",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "yi2 dung4",
     )
@@ -2772,7 +2799,14 @@ def test_I_walk_out_of_house():
         ),
         syntax_hints=[IGNORE_GOAL],
     )
-    assert generated_tokens(situation) == ("wo3", "bu4 sying2", "chu1", "wu1")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "bu4 sying2",
+        "chu1",
+        "yi1",
+        "jyan1",
+        "wu1",
+    )
 
 
 def test_big_truck_updated():
@@ -2785,7 +2819,7 @@ def test_big_truck_updated():
         always_relations=[(bigger_than(truck1, truck2))],
     )
     assert not gravitationally_aligned_axis_is_largest(TRUCK, GAILA_PHASE_1_ONTOLOGY)
-    assert generated_tokens(situation) == ("da4", "ka3 che1")
+    assert generated_tokens(situation) == ("yi1", "lyang4", "da4", "ka3 che1")
 
 
 def test_tall_book_updated():
@@ -2798,7 +2832,7 @@ def test_tall_book_updated():
         always_relations=[(bigger_than(book1, book2))],
     )
     assert gravitationally_aligned_axis_is_largest(BOOK, GAILA_PHASE_1_ONTOLOGY)
-    assert generated_tokens(situation) == ("gau1 da4", "shu1")
+    assert generated_tokens(situation) == ("yi1", "ben3", "gau1 da4", "shu1")
 
 
 def test_small_truck_updated():
@@ -2811,7 +2845,7 @@ def test_small_truck_updated():
         always_relations=[(bigger_than(truck2, truck1))],
     )
     assert not gravitationally_aligned_axis_is_largest(TRUCK, GAILA_PHASE_1_ONTOLOGY)
-    assert generated_tokens(situation) == ("syau3", "ka3 che1")
+    assert generated_tokens(situation) == ("yi1", "lyang4", "syau3", "ka3 che1")
 
 
 def test_short_book_updated():
@@ -2824,7 +2858,7 @@ def test_short_book_updated():
         always_relations=[(bigger_than(book2, book1))],
     )
     assert gravitationally_aligned_axis_is_largest(BOOK, GAILA_PHASE_1_ONTOLOGY)
-    assert generated_tokens(situation) == ("dwan3", "shu1")
+    assert generated_tokens(situation) == ("yi1", "ben3", "dwan3", "shu1")
 
 
 # there is no under/below distinction in Chinese
@@ -2838,9 +2872,13 @@ def test_ball_under_below_cookie():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "sya4 myan4",
         "de",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 
@@ -2855,9 +2893,13 @@ def test_ball_over_cookie():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "shang4 myan4",
         "de",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 
@@ -2873,9 +2915,13 @@ def test_ball_above_cookie():
     )
     assert generated_tokens(situation) == (
         "dzai4",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "shang4 fang1",
         "de",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 
@@ -2890,9 +2936,13 @@ def test_ball_far_from_cookie():
     )
     assert generated_tokens(situation) == (
         "li2",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "hen3 ywan3",
         "de",
+        "yi1",
+        "ge4",
         "chyou2",
     )
 
@@ -3019,7 +3069,15 @@ def test_I_run_out_of_car_slowly():
         ),
         syntax_hints=[IGNORE_GOAL],
     )
-    assert generated_tokens(situation) == ("wo3", "man4 man", "pau3", "chu1", "chi4 che1")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "man4 man",
+        "pau3",
+        "chu1",
+        "yi1",
+        "lyang4",
+        "chi4 che1",
+    )
 
 
 def test_dad_slowly_grabs_cookie():
@@ -3053,6 +3111,8 @@ def test_dad_slowly_grabs_cookie():
         "ba4 ba4",
         "man4 man",
         "chyang3 na2 chi3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
     )
 
@@ -3099,9 +3159,13 @@ def test_i_shove_a_ball_on_a_table_dao():
     assert generated_tokens(situation) == (
         "wo3",
         "ba3",
+        "yi1",
+        "ge4",
         "chyou2",
         "yung4 li4 twei1",
         "dau4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -3133,7 +3197,13 @@ def test_i_shove_a_table():
             )
         ],
     )
-    assert generated_tokens(situation) == ("wo3", "yung4 li4 twei1", "jwo1 dz")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "yung4 li4 twei1",
+        "yi1",
+        "jang1",
+        "jwo1 dz",
+    )
 
 
 def test_i_push_a_table():
@@ -3148,7 +3218,7 @@ def test_i_push_a_table():
             )
         ],
     )
-    assert generated_tokens(situation) == ("wo3", "twei1", "jwo1 dz")
+    assert generated_tokens(situation) == ("wo3", "twei1", "yi1", "jang1", "jwo1 dz")
 
 
 def test_i_push_table_down_slowly():
@@ -3182,6 +3252,8 @@ def test_i_push_table_down_slowly():
         "wo3",
         "man4 man",
         "ba3",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "twei1",
         "sya4 lai2",
@@ -3216,7 +3288,15 @@ def test_i_throw_ball_down():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("wo3", "ba3", "chyou2", "reng1", "sya4 lai2")
+    assert generated_tokens(situation) == (
+        "wo3",
+        "ba3",
+        "yi1",
+        "ge4",
+        "chyou2",
+        "reng1",
+        "sya4 lai2",
+    )
 
 
 def test_dad_passes_the_cookie_down_to_me():
@@ -3236,7 +3316,6 @@ def test_dad_passes_the_cookie_down_to_me():
                             dad,
                             SpatialPath(
                                 operator=TOWARD,
-                                # TODO : fix ground checking in language generator
                                 reference_source_object=Region(
                                     situation_object(GROUND), distance=DISTAL
                                 ),
@@ -3252,6 +3331,8 @@ def test_dad_passes_the_cookie_down_to_me():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "di4",
         "sya4 lai2",
@@ -3321,6 +3402,8 @@ def test_dad_tosses_the_cookie_up_to_me():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "reng1",
         "chi3 lai2",
@@ -3367,6 +3450,8 @@ def test_bird_flies_up_towards_mum():
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
     assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
         "nyau3",
         "chau2",
         "ma1 ma1",
@@ -3402,7 +3487,14 @@ def test_bird_flies_away_from_mum():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "li2", "ma1 ma1", "fei1")
+    assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
+        "nyau3",
+        "li2",
+        "ma1 ma1",
+        "fei1",
+    )
 
 
 def test_dad_passes_me_cookie():
@@ -3422,6 +3514,8 @@ def test_dad_passes_me_cookie():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "di4",
         "gei3",
@@ -3459,6 +3553,8 @@ def test_you_toss_me_cookie():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "reng1",
         "gei3",
@@ -3495,6 +3591,8 @@ def test_you_toss_mum_cookie():
     assert generated_tokens(situation) == (
         "ni3",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "di4",
         "gei3",
@@ -3523,6 +3621,8 @@ def test_passing_for_phase1():
     assert generated_tokens(situation) == (
         "ba4 ba4",
         "ba3",
+        "yi1",
+        "kwai4",
         "chyu1 chi2 bing3",
         "di4",
         "gei3",
@@ -3586,7 +3686,13 @@ def test_non_salient_in_path():
             )
         ],
     )
-    assert generated_tokens(situation) == ("ni3", "chr1", "chyu1 chi2 bing3")
+    assert generated_tokens(situation) == (
+        "ni3",
+        "chr1",
+        "yi1",
+        "kwai4",
+        "chyu1 chi2 bing3",
+    )
 
 
 def test_not_yet_used_operator():
@@ -3646,7 +3752,14 @@ def test_bird_flies_away_from_mum_region():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "li2", "ma1 ma1", "fei1")
+    assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
+        "nyau3",
+        "li2",
+        "ma1 ma1",
+        "fei1",
+    )
 
 
 def test_region_as_subject_should_fail():
@@ -3949,6 +4062,8 @@ def test_drink_from():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "tsung2",
+        "yi1",
+        "ge4",
         "bei1 dz",
         "he1",
         "shwei3",
@@ -4002,9 +4117,13 @@ def test_order_ba_and_prep_phrase():
     assert generated_tokens(situation) == (
         "ma1 ma1",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
         "ba3",
+        "yi1",
+        "ben3",
         "shu1",
         "twei1",
         "sya4 lai2",
@@ -4037,7 +4156,14 @@ def test_move_should_have_dao():
             )
         ],
     )
-    assert generated_tokens(situation) == ("ma1 ma1", "chau2", "shu1", "yi2 dung4")
+    assert generated_tokens(situation) == (
+        "ma1 ma1",
+        "chau2",
+        "yi1",
+        "ben3",
+        "shu1",
+        "yi2 dung4",
+    )
 
 
 def test_move_should_have_dao_away():
@@ -4068,4 +4194,11 @@ def test_move_should_have_dao_away():
             )
         ],
     )
-    assert generated_tokens(situation) == ("ma1 ma1", "li2", "shu1", "yi2 dung4")
+    assert generated_tokens(situation) == (
+        "ma1 ma1",
+        "li2",
+        "yi1",
+        "ben3",
+        "shu1",
+        "yi2 dung4",
+    )

--- a/tests/language_specific/chinese/test_chinese_language_generator.py
+++ b/tests/language_specific/chinese/test_chinese_language_generator.py
@@ -1888,9 +1888,13 @@ def test_bird_flies_path_beside():
         ],
     )
     assert generated_tokens(situation) == (
+        "yi1",
+        "jr1",
         "nyau3",
         "fei1",
         "gwo4",
+        "yi1",
+        "lyang4",
         "chi4 che1",
         "pang2 byan1",
     )
@@ -1907,6 +1911,8 @@ def test_ball_fell_on_ground():
         after_action_relations=[on(ball, ground)],
     )
     assert generated_tokens(situation) == (
+        "yi1",
+        "ge4",
         "chyou2",
         "dye2 dau3",
         "dau4",
@@ -1943,6 +1949,8 @@ def test_mom_sits_on_a_table():
         "ma1 ma1",
         "dzwo4",
         "dzai4",
+        "yi1",
+        "jang1",
         "jwo1 dz",
         "shang4",
     )
@@ -1959,7 +1967,13 @@ def test_falling_down():
         actions=[Action(FALL, argument_roles_to_fillers=[(THEME, ball)])],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("chyou2", "dye2 dau3", "sya4 lai2")
+    assert generated_tokens(situation) == (
+        "yi1",
+        "ge4",
+        "chyou2",
+        "dye2 dau3",
+        "sya4 lai2",
+    )
 
 
 # sit down testing
@@ -2037,7 +2051,7 @@ def test_bird_flies_up():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "fei1", "chi3 lai2")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "fei1", "chi3 lai2")
 
 
 # direction of flight = up
@@ -2068,7 +2082,7 @@ def test_bird_flies_down():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "fei1", "sya4 lai2")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "fei1", "sya4 lai2")
 
 
 """GO/COME BEHAVE DIFFERENTLY IN CHINESE WITH ADVMODS -- CHECKED BY NATIVE SPEAKER"""
@@ -2102,7 +2116,7 @@ def test_going_up():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "shang4", "chyu4")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "shang4", "chyu4")
 
 
 # testing going down
@@ -2132,7 +2146,7 @@ def test_going_down():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "sya4", "chyu4")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "sya4", "chyu4")
 
 
 # testing coming up
@@ -2164,7 +2178,7 @@ def test_coming_up():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "shang4", "lai2")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "shang4", "lai2")
 
 
 # testing going down
@@ -2194,7 +2208,7 @@ def test_coming_down():
         ],
         syntax_hints=[USE_ADVERBIAL_PATH_MODIFIER],
     )
-    assert generated_tokens(situation) == ("nyau3", "sya4", "lai2")
+    assert generated_tokens(situation) == ("yi1", "jr1", "nyau3", "sya4", "lai2")
 
 
 # direction of jumping
@@ -2249,13 +2263,14 @@ def test_jump_down():
 
 """GO WITH GOAL -- CHECKED BY NATIVE SPEAKER"""
 
+# TODO: check/fix this
 
 # this tests dao for going to a region, in which case we use the bare NP instead of a localiser phrase
 def test_to_regions_as_goal():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation(Region(goal_object, distance=PROXIMAL), goal_object)
-    ) == ("gou3", "chyu4", "syang1 dz")
+    ) == ("yi1", "jr1", "gou3", "chyu4", "yi1", "ge4", "syang1 dz")
 
 
 # this tests being inside a region
@@ -2263,7 +2278,7 @@ def test_in_region_as_goal():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation(Region(goal_object, distance=INTERIOR), goal_object)
-    ) == ("gou3", "chyu4", "dau4", "syang1 dz", "li3")
+    ) == ("yi1", "jr1", "gou3", "chyu4", "dau4", "yi1", "ge4", "syang1 dz", "li3")
 
 
 # this tests being next to a region
@@ -2282,7 +2297,7 @@ def test_beside_region_as_goal():
             ),
             goal_object,
         )
-    ) == ("gou3", "chyu4", "dau4", "syang1 dz", "pang2 byan1")
+    ) == ("yi1", "jr1", "gou3", "chyu4", "dau4", "yi1", "ge4", "syang1 dz", "pang2 byan1")
 
 
 # this tests going behind a region
@@ -2300,7 +2315,7 @@ def test_behind_region_as_goal():
             ),
             goal_object,
         )
-    ) == ("gou3", "chyu4", "dau4", "syang1 dz", "hou4 myan4")
+    ) == ("yi1", "jr1", "gou3", "chyu4", "dau4", "yi1", "ge4", "syang1 dz", "hou4 myan4")
 
 
 # this tests going in front of a region
@@ -2318,7 +2333,17 @@ def test_in_front_of_region_as_goal():
             ),
             goal_object,
         )
-    ) == ("gou3", "chyu4", "dau4", "syang1 dz", "chyan2 myan4")
+    ) == (
+        "yi1",
+        "jr1",
+        "gou3",
+        "chyu4",
+        "dau4",
+        "yi1",
+        "ge4",
+        "syang1 dz",
+        "chyan2 myan4",
+    )
 
 
 # this tests going over a region
@@ -2330,7 +2355,17 @@ def test_over_region_as_goal():
             Region(goal_object, distance=PROXIMAL, direction=GRAVITATIONAL_UP),
             goal_object,
         )
-    ) == ("gou3", "chyu4", "dau4", "jwo1 dz", "shang4 myan4")
+    ) == (
+        "yi1",
+        "jr1",
+        "gou3",
+        "chyu4",
+        "dau4",
+        "yi1",
+        "jang1",
+        "jwo1 dz",
+        "shang4 myan4",
+    )
 
 
 # this tests going under a region
@@ -2342,7 +2377,7 @@ def test_under_region_as_goal():
             Region(goal_object, distance=PROXIMAL, direction=GRAVITATIONAL_DOWN),
             goal_object,
         )
-    ) == ("gou3", "chyu4", "dau4", "jwo1 dz", "sya4 myan4")
+    ) == ("yi1", "jr1", "gou3", "chyu4", "dau4", "yi1", "jang1", "jwo1 dz", "sya4 myan4")
 
 
 """COME WITH GOAL-- CHECKED BY NATIVE SPEAKER"""
@@ -2353,15 +2388,16 @@ def test_to_regions_as_goal_come():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation_come(Region(goal_object, distance=PROXIMAL), goal_object)
-    ) == ("gou3", "lai2", "syang1 dz")
+    ) == ("yi1", "jr1", "gou3", "lai2", "syang1 dz")
 
 
+# TODO: fix this
 # this tests being inside a region
 def test_in_region_as_goal_come():
     goal_object = situation_object(BOX, properties=[HOLLOW])
     assert generated_tokens(
         region_as_goal_situation_come(Region(goal_object, distance=INTERIOR), goal_object)
-    ) == ("gou3", "lai2", "dau4", "syang1 dz", "li3")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "syang1 dz", "li3")
 
 
 # this tests being next to a region
@@ -2380,7 +2416,7 @@ def test_beside_region_as_goal_come():
             ),
             goal_object,
         )
-    ) == ("gou3", "lai2", "dau4", "syang1 dz", "pang2 byan1")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "ge4", "syang1 dz", "pang2 byan1")
 
 
 # this tests going behind a region
@@ -2398,7 +2434,7 @@ def test_behind_region_as_goal_come():
             ),
             goal_object,
         )
-    ) == ("gou3", "lai2", "dau4", "syang1 dz", "hou4 myan4")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "ge4", "syang1 dz", "hou4 myan4")
 
 
 # this tests going in front of a region
@@ -2416,7 +2452,7 @@ def test_in_front_of_region_as_goal_come():
             ),
             goal_object,
         )
-    ) == ("gou3", "lai2", "dau4", "syang1 dz", "chyan2 myan4")
+    ) == ("yi1", "jr1", "gou3", "lai2", "dau4", "yi1", "ge4", "syang1 dz", "chyan2 myan4")
 
 
 # this tests going over a region


### PR DESCRIPTION
This adds the 1 + CLF + noun structure to Chinese singular nouns. However, it also breaks most of our learning since we don't have a reliable way to acquire the classifiers right now which is why CI is broken. 

I believe that this is the behaviour we'd actually expect under our current learning algorithms so I'm unsure exactly how to continue. My original proposed solution to the generics learning problem was to consider the interpretation of the nouns in generic statements to be plural by default so we don't have to deal with this (i.e. we just have to learn `2/many_nouns` vs. `nouns`), but this is quite hackish so I don't know if it's a good fallback or not and would require us to change our generics perceptions to be plural. 

In either case for the generics, this may potentially pose a problem for real learning of Chinese classifiers. I haven't yet tried running the entire learner on it, but if it fails most of the unit tests, I'm not optimistic. 