### PR TITLE
Create separate Chinese classifier curriculum in curriculum_to_html

### DIFF
--- a/adam/curriculum/phase2_curriculum.py
+++ b/adam/curriculum/phase2_curriculum.py
@@ -978,10 +978,6 @@ def build_gaila_phase_2_curriculum(
             # Pursuit
             make_pursuit_curriculum(num_samples, num_noise_objects, language_generator),
             build_pursuit_curriculum(num_samples, num_noise_objects, language_generator),
-            # Chinese classifiers
-            build_classifier_curriculum(
-                num_samples, num_noise_objects, language_generator
-            ),
             # Object learner experiment
             build_object_learner_experiment_curriculum_train(
                 num_samples, num_noise_objects, language_generator

--- a/adam/curriculum_to_html.py
+++ b/adam/curriculum_to_html.py
@@ -51,7 +51,10 @@ from adam.curriculum.phase2_curriculum import (
 )
 from adam.curriculum.preposition_curriculum import make_prepositions_curriculum
 from adam.curriculum.pursuit_curriculum import make_pursuit_curriculum
-from adam.curriculum.phase1_curriculum import build_gaila_phase_1_curriculum
+from adam.curriculum.phase1_curriculum import (
+    build_gaila_phase_1_curriculum,
+    build_classifier_curriculum,
+)
 from adam.curriculum import InstanceGroup
 from adam.curriculum.verbs_with_dynamic_prepositions_curriculum import (
     make_verb_with_dynamic_prepositions_curriculum,
@@ -151,6 +154,7 @@ STR_TO_CURRICULUM: Mapping[str, CURRICULUM_BUILDER] = {
     "imprecise-size": make_imprecise_size_curriculum,
     "subtle-verb-distinction": make_subtle_verb_distinctions_curriculum,
     "integrated-experiment": integrated_pursuit_learner_experiment_curriculum,
+    "chinese-classifiers": build_classifier_curriculum,
     "phase2": build_gaila_phase_2_curriculum,
 }
 
@@ -179,11 +183,15 @@ def main(params: Parameters) -> None:
             if params.has_namespace("curriculum_params")
             else Parameters.empty(namespace_prefix="curriculum_params"),
         )
-    else:
+    elif curriculum_string == "phase2":
         curriculum_to_render = STR_TO_CURRICULUM[curriculum_string](
             num_samples,
             num_noise_objects,
             integrated_experiment_language_generator(language_mode),
+        )
+    else:
+        curriculum_to_render = STR_TO_CURRICULUM[curriculum_string](
+            num_samples, num_noise_objects, phase2_language_generator(language_mode)
         )
     sort_by_utterance_length_flag = params.boolean("sort_by_utterance", default=False)
     if sort_by_utterance_length_flag:

--- a/parameters/html/curriculum_to_html.chinese_classifiers.params
+++ b/parameters/html/curriculum_to_html.chinese_classifiers.params
@@ -1,0 +1,5 @@
+_includes:
+    - curriculum_to_html.params
+
+curriculum: "chinese-classifiers"
+language_mode: CHINESE


### PR DESCRIPTION
So that we can run it in Chinese separate from the rest of the Phase 2 curriculum (which was generated in English), as we probably want to.