### PR TITLE
Run travis CI on Angular UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: python
-
 jobs:
     include:
-        - python: "3.6"
+        - language: python
+          python: "3.6"
           stage: test
           install:
             - pip install --upgrade "pip<20.3" setuptools wheel
@@ -13,7 +12,23 @@ jobs:
               - make check
           cache:
             pip: true
-        - python: "pypy3.6-7.1.1"
+#       We put this node job second because we have one-job execution
+#       and we'd prefer these to fail quickly before we run all the python tests
+        - language: node_js
+          node_js: 14
+          before_install:
+            - npm i -g npm@8
+          before_script:
+            - cd angular-viewer/adam-angular-demo
+            - npm install
+          script:
+            - echo "node version $(node -v) running"
+            - echo "npm versions $(npm --version) running"
+            - make check
+          cache:
+            npm: true
+        - language: python
+          python: "pypy3.6-7.1.1"
           stage: test
           install:
             - pip install --upgrade "pip<20.3" setuptools wheel
@@ -28,4 +43,3 @@ jobs:
             pip: true
 #          after_success:
 #              - codecov -t 452b6965-c9da-4306-97d5-a5e86626af8f
-

--- a/angular-viewer/adam-angular-demo/Makefile
+++ b/angular-viewer/adam-angular-demo/Makefile
@@ -3,11 +3,7 @@ default:
 
 SHELL=/usr/bin/env bash
 
-BASH_FILES=$(shell git ls-files --cached --others --exclude-standard '../*.sh' | sort | tr '\n' ' ')
 PRETTIER_FILES=. ../../README.md ../../RELEASE_PROCESS.md ../../adam/experiment/README.md
-
-shellcheck:
-	node_modules/shellcheck/shellcheck-stable/shellcheck --exclude=SC1091 --shell=bash $(BASH_FILES)
 
 stylelint:
 	npx stylelint "src/**/*.css"
@@ -22,7 +18,7 @@ prettier-check:
 	npx prettier --check $(PRETTIER_FILES)
 
 # Re-enable stylelint once we have a configuration for styles.css
-check: prettier-check lint # stylelint shellcheck
+check: prettier-check lint # stylelint
 
 precommit: prettier-fix check
 


### PR DESCRIPTION
Closes #1059 

Changes to the .travel.yml configuration file so that the Angular UI app runs `make check` as part of CI automatically. This step is placed after the python recommit checks but before the python tests based on speed to failure.