### PR TITLE
Update P3 curriculum for M4 goals

### DIFF
--- a/adam/curriculum/curriculum_to_yaml.py
+++ b/adam/curriculum/curriculum_to_yaml.py
@@ -4,11 +4,21 @@ from typing import Any, MutableMapping
 import yaml
 
 from adam.curriculum.curriculum_utils import Phase3InstanceGroup
-from adam.curriculum.phase3_curriculum import Phase3OneObjectsCurriculum
+from adam.curriculum.phase3_curriculum import (
+    phase_3_one_objects_curriculum,
+    phase_3_one_core_objects_curriculum,
+    phase_3_one_stretch_objects_curriculum,
+    phase_3_m4_core_eval,
+    phase_3_m4_stretch_eval,
+)
 from adam.language_specific.english.english_language_generator import (
     GAILA_PHASE_3_LANGUAGE_GENERATOR,
 )
-from adam.paths import TRAINING_CURRICULUM_DIR, GENERATION_YAML_DIR_NAME
+from adam.paths import (
+    TRAINING_CURRICULUM_DIR,
+    GENERATION_YAML_DIR_NAME,
+    TESTING_CURRICULUM_DIR,
+)
 
 
 def curriculum_to_yaml(
@@ -32,12 +42,31 @@ def curriculum_to_yaml(
             yaml.dump(output_dict, yaml_file)
 
 
+# TODO: Adapt this entry point to take a parameters file to build a set of curriculum
+# So we can only rebuild the curriculum we need to rather than all curriculum every time
+# See: https://github.com/isi-vista/adam/issues/1071
 def main():
-    phase_3_one_object = Phase3OneObjectsCurriculum()
-    curriculum = phase_3_one_object(1, 5, GAILA_PHASE_3_LANGUAGE_GENERATOR)
-    curriculum_to_yaml(
-        curriculum, TRAINING_CURRICULUM_DIR / curriculum.name() / GENERATION_YAML_DIR_NAME
-    )
+    # Training Curriculums
+    for curriculum_builder in [
+        phase_3_one_objects_curriculum,
+        phase_3_one_core_objects_curriculum,
+        phase_3_one_stretch_objects_curriculum,
+    ]:
+        curriculum = curriculum_builder(1, 5, GAILA_PHASE_3_LANGUAGE_GENERATOR)
+        curriculum_to_yaml(
+            curriculum,
+            TRAINING_CURRICULUM_DIR / curriculum.name() / GENERATION_YAML_DIR_NAME,
+            num_generated_per_instance=10,
+        )
+
+    # Testing Curriculums
+    for curriculum_builder in [phase_3_m4_stretch_eval, phase_3_m4_core_eval]:
+        curriculum = curriculum_builder(1, 5, GAILA_PHASE_3_LANGUAGE_GENERATOR)
+        curriculum_to_yaml(
+            curriculum,
+            TESTING_CURRICULUM_DIR / curriculum.name() / GENERATION_YAML_DIR_NAME,
+            num_generated_per_instance=1,
+        )
 
 
 if __name__ == "__main__":

--- a/adam/curriculum/phase3_curriculum.py
+++ b/adam/curriculum/phase3_curriculum.py
@@ -1,5 +1,5 @@
-from abc import ABC, abstractmethod
 from itertools import chain
+from typing_extensions import Protocol
 
 from adam.curriculum.curriculum_utils import (
     Phase3InstanceGroup,
@@ -11,12 +11,13 @@ from adam.language.dependency import LinearizedDependencyTree
 from adam.language.language_generator import LanguageGenerator
 from adam.language_specific.english.english_language_generator import (
     IGNORE_COLORS,
-    IGNORE_SHAPE_PROPERTY,
+)
+from adam.ontology.phase1_ontology import (
+    PHASE_3_M4_STRETCH_CONCEPT,
+    PHASE_3_M4_CORE_CONCEPT,
 )
 from adam.ontology.phase3_ontology import (
     GAILA_PHASE_3_ONTOLOGY,
-    SHAPE_PROPERTY_DESCRIPTION,
-    BLOCK,
 )
 from adam.situation.high_level_semantics_situation import HighLevelSemanticsSituation
 from vistautils.parameters import Parameters
@@ -27,8 +28,7 @@ from adam.situation.templates.phase1_templates import (
 )
 
 
-class Phase3CurriculumCallable(ABC):
-    @abstractmethod
+class Phase3CurriculumCallable(Protocol):
     def __call__(
         self,
         num_samples: int,
@@ -39,52 +39,169 @@ class Phase3CurriculumCallable(ABC):
         params: Parameters,
     ) -> Phase3InstanceGroup:
         raise NotImplementedError(
-            "The base Phase3CurriculumCallable does not implement a curriculum return."
+            "The protocol Phase3CurriculumCallable does not implement a curriculum return."
         )
 
 
-class Phase3OneObjectsCurriculum(Phase3CurriculumCallable):
-    """A curriculum with a single object from the Phase 3 selection."""
+def phase_3_one_core_objects_curriculum(  # pylint: disable=unused-argument
+    num_samples: int,
+    num_noise_objects: int,
+    language_generator: LanguageGenerator[
+        HighLevelSemanticsSituation, LinearizedDependencyTree
+    ],
+    params: Parameters = Parameters.empty(),
+) -> Phase3InstanceGroup:
+    return phase3_instances(
+        "each-core-object-by-itself",
+        chain(
+            *[
+                all_possible(
+                    Phase1SituationTemplate(
+                        "single-core-object-phase3",
+                        salient_object_variables=[
+                            phase3_standard_object(
+                                "single-object",
+                                required_properties=[PHASE_3_M4_CORE_CONCEPT],
+                            )
+                        ],
+                        syntax_hints=[IGNORE_COLORS],
+                    ),
+                    chooser=CHOOSER_FACTORY(),
+                    ontology=GAILA_PHASE_3_ONTOLOGY,
+                ),
+            ]
+        ),
+    )
 
-    def __call__(
-        self,
-        num_samples: int,
-        num_noise_objects: int,
-        language_generator: LanguageGenerator[
-            HighLevelSemanticsSituation, LinearizedDependencyTree
-        ],
-        params: Parameters = Parameters.empty(),
-    ) -> Phase3InstanceGroup:
-        return phase3_instances(
-            "each-object-by-itself",
-            chain(
-                *[
-                    all_possible(
-                        Phase1SituationTemplate(
-                            "single-object-phase3",
-                            salient_object_variables=[
-                                phase3_standard_object("single-object")
-                            ],
-                            syntax_hints=[IGNORE_COLORS],
-                        ),
-                        chooser=CHOOSER_FACTORY(),
-                        ontology=GAILA_PHASE_3_ONTOLOGY,
+
+def phase_3_one_stretch_objects_curriculum(  # pylint: disable=unused-argument
+    num_samples: int,
+    num_noise_objects: int,
+    language_generator: LanguageGenerator[
+        HighLevelSemanticsSituation, LinearizedDependencyTree
+    ],
+    params: Parameters = Parameters.empty(),
+) -> Phase3InstanceGroup:
+    return phase3_instances(
+        "each-stretch-object-by-itself",
+        chain(
+            *[
+                all_possible(
+                    Phase1SituationTemplate(
+                        "stretch-single-object-phase3",
+                        salient_object_variables=[
+                            phase3_standard_object(
+                                "single-object",
+                                required_properties=[PHASE_3_M4_STRETCH_CONCEPT],
+                            )
+                        ],
+                        syntax_hints=[IGNORE_COLORS],
                     ),
-                    all_possible(
-                        Phase1SituationTemplate(
-                            "block_types",
-                            salient_object_variables=[
-                                phase3_standard_object(
-                                    "block",
-                                    BLOCK,
-                                    added_properties=[SHAPE_PROPERTY_DESCRIPTION],
-                                )
-                            ],
-                            syntax_hints=[IGNORE_SHAPE_PROPERTY],
-                        ),
-                        chooser=CHOOSER_FACTORY(),
-                        ontology=GAILA_PHASE_3_ONTOLOGY,
+                    chooser=CHOOSER_FACTORY(),
+                    ontology=GAILA_PHASE_3_ONTOLOGY,
+                ),
+            ]
+        ),
+    )
+
+
+def phase_3_one_objects_curriculum(  # pylint: disable=unused-argument
+    num_samples: int,
+    num_noise_objects: int,
+    language_generator: LanguageGenerator[
+        HighLevelSemanticsSituation, LinearizedDependencyTree
+    ],
+    params: Parameters = Parameters.empty(),
+) -> Phase3InstanceGroup:
+    return phase3_instances(
+        "each-object-by-itself",
+        chain(
+            *[
+                all_possible(
+                    Phase1SituationTemplate(
+                        "single-object-phase3",
+                        salient_object_variables=[
+                            phase3_standard_object("single-object")
+                        ],
+                        syntax_hints=[IGNORE_COLORS],
                     ),
-                ]
-            ),
-        )
+                    chooser=CHOOSER_FACTORY(),
+                    ontology=GAILA_PHASE_3_ONTOLOGY,
+                ),
+            ]
+        ),
+    )
+
+
+def phase_3_m4_core_eval(  # pylint: disable=unused-argument
+    num_samples: int,
+    num_noise_objects: int,
+    language_generator: LanguageGenerator[
+        HighLevelSemanticsSituation, LinearizedDependencyTree
+    ],
+    params: Parameters = Parameters.empty(),
+) -> Phase3InstanceGroup:
+    return phase3_instances(
+        "phase3-m4-core-eval",
+        chain(
+            *[
+                all_possible(
+                    Phase1SituationTemplate(
+                        "m4-core-eval",
+                        salient_object_variables=[
+                            phase3_standard_object(
+                                "object-background-1",
+                                required_properties=[PHASE_3_M4_CORE_CONCEPT],
+                            )
+                        ],
+                        background_object_variables=[
+                            phase3_standard_object(
+                                "object-background-2",
+                                required_properties=[PHASE_3_M4_STRETCH_CONCEPT],
+                            )
+                        ],
+                        syntax_hints=[IGNORE_COLORS],
+                    ),
+                    chooser=CHOOSER_FACTORY(),
+                    ontology=GAILA_PHASE_3_ONTOLOGY,
+                ),
+            ]
+        ),
+    )
+
+
+def phase_3_m4_stretch_eval(  # pylint: disable=unused-argument
+    num_samples: int,
+    num_noise_objects: int,
+    language_generator: LanguageGenerator[
+        HighLevelSemanticsSituation, LinearizedDependencyTree
+    ],
+    params: Parameters = Parameters.empty(),
+) -> Phase3InstanceGroup:
+    return phase3_instances(
+        "phase3-m4-stretch-eval",
+        chain(
+            *[
+                all_possible(
+                    Phase1SituationTemplate(
+                        "m4-stretch-eval",
+                        salient_object_variables=[
+                            phase3_standard_object(
+                                "object-background-1",
+                                required_properties=[PHASE_3_M4_STRETCH_CONCEPT],
+                            )
+                        ],
+                        background_object_variables=[
+                            phase3_standard_object(
+                                "object-background-2",
+                                required_properties=[PHASE_3_M4_STRETCH_CONCEPT],
+                            )
+                        ],
+                        syntax_hints=[IGNORE_COLORS],
+                    ),
+                    chooser=CHOOSER_FACTORY(),
+                    ontology=GAILA_PHASE_3_ONTOLOGY,
+                ),
+            ]
+        ),
+    )

--- a/adam/language_specific/english/english_phase_3_lexicon.py
+++ b/adam/language_specific/english/english_phase_3_lexicon.py
@@ -36,6 +36,10 @@ from adam.ontology.phase3_ontology import (
     CUBIC,
     PLASTIC,
     WOOD,
+    PYRAMID_BLOCK,
+    SPHERICAL_BLOCK,
+    CUBE_BLOCK,
+    MUG,
 )
 
 GAILA_PHASE_3_ENGLISH_LEXICON = OntologyLexicon(
@@ -50,10 +54,14 @@ GAILA_PHASE_3_ENGLISH_LEXICON = OntologyLexicon(
         (CHAIR, LexiconEntry("chair", NOUN, plural_form="chairs")),
         (SOFA, LexiconEntry("sofa", NOUN, plural_form="sofas")),
         (BLOCK, LexiconEntry("block", NOUN, plural_form="blocks")),
+        (PYRAMID_BLOCK, LexiconEntry("pyramid", NOUN, plural_form="pyramids")),
+        (SPHERICAL_BLOCK, LexiconEntry("sphere", NOUN, plural_form="spheres")),
+        (CUBE_BLOCK, LexiconEntry("cube", NOUN, plural_form="cubes")),
         (BOX, LexiconEntry("box", NOUN, plural_form="boxes")),
         (FLOOR, LexiconEntry("floor", NOUN, plural_form="floors")),
         (WINDOW, LexiconEntry("window", NOUN, plural_form="windows")),
         (CUP, LexiconEntry("cup", NOUN, plural_form="cups")),
+        (MUG, LexiconEntry("mug", NOUN, plural_form="mugs")),
         (PAPER, LexiconEntry("paper", NOUN, plural_form="papers")),
         (DESK, LexiconEntry("desk", NOUN, plural_form="desks")),
         (TOY_TRUCK, LexiconEntry("truck", NOUN, plural_form="trucks")),

--- a/adam/ontology/phase1_ontology.py
+++ b/adam/ontology/phase1_ontology.py
@@ -241,6 +241,10 @@ PHASE_2_CONCEPT = OntologyNode("phase-2-concept")
 subtype(PHASE_2_CONCEPT, PROPERTY)
 PHASE_3_CONCEPT = OntologyNode("phase-3-concept")
 subtype(PHASE_3_CONCEPT, PROPERTY)
+PHASE_3_M4_CORE_CONCEPT = OntologyNode("phase-3-m4-core-concept")
+subtype(PHASE_3_M4_CORE_CONCEPT, PHASE_3_CONCEPT)
+PHASE_3_M4_STRETCH_CONCEPT = OntologyNode("phase-3-m4-stretch-concept")
+subtype(PHASE_3_M4_STRETCH_CONCEPT, PHASE_3_M4_CORE_CONCEPT)
 
 COLOR = OntologyNode("color")
 subtype(COLOR, PERCEIVABLE_PROPERTY)
@@ -452,7 +456,12 @@ subtype(DOOR, FURNITURE)
 BALL = OntologyNode(
     "ball",
     [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE, ROLLABLE, RED, BLUE, GREEN, BLACK, WHITE],
-    non_inheritable_properties=[PHASE_1_CONCEPT, PHASE_2_CONCEPT, PHASE_3_CONCEPT],
+    non_inheritable_properties=[
+        PHASE_1_CONCEPT,
+        PHASE_2_CONCEPT,
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
 )
 subtype(BALL, TOY)
 
@@ -489,6 +498,7 @@ PAPER = OntologyNode(
         WHITE,
         TWO_DIMENSIONAL,
     ],
+    non_inheritable_properties=[PHASE_3_CONCEPT],
 )
 subtype(PAPER, INANIMATE_OBJECT)
 BOOK = OntologyNode(
@@ -502,7 +512,12 @@ BOOK = OntologyNode(
         GREEN,
         INTEGRATED_EXPERIMENT_PROP,
     ],
-    non_inheritable_properties=[PHASE_1_CONCEPT, PHASE_2_CONCEPT, PHASE_3_CONCEPT],
+    non_inheritable_properties=[
+        PHASE_1_CONCEPT,
+        PHASE_2_CONCEPT,
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
 )
 subtype(BOOK, INANIMATE_OBJECT)
 HOUSE = OntologyNode(
@@ -623,7 +638,12 @@ BOX = OntologyNode(
         PERSON_CAN_HAVE,
         LIGHT_BROWN,
     ],
-    non_inheritable_properties=[PHASE_1_CONCEPT, PHASE_2_CONCEPT, PHASE_3_CONCEPT],
+    non_inheritable_properties=[
+        PHASE_1_CONCEPT,
+        PHASE_2_CONCEPT,
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
 )
 subtype(BOX, CONTAINER)
 

--- a/adam/ontology/phase3_ontology.py
+++ b/adam/ontology/phase3_ontology.py
@@ -34,6 +34,10 @@ from adam.ontology.phase1_ontology import (
     PERSON_CAN_HAVE,
     MATERIAL,
     SHAPE_PROPERTY_DESCRIPTION,
+    CONTAINER,
+    _PAPER_SCHEMA,
+    PHASE_3_M4_CORE_CONCEPT,
+    PHASE_3_M4_STRETCH_CONCEPT,
 )
 from adam.ontology.structural_schema import ObjectStructuralSchema
 
@@ -57,7 +61,7 @@ subtype(SPHERICAL, SHAPE_PROPERTY_DESCRIPTION)
 # Base Property Objects
 BLOCK = OntologyNode(
     "block",
-    [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE],
+    [PERSON_CAN_HAVE],
     non_inheritable_properties=[PHASE_3_CONCEPT],
 )
 subtype(BLOCK, TOY)
@@ -114,6 +118,44 @@ TOY_SEDAN = OntologyNode(
 )
 subtype(TOY_SEDAN, TOY)
 
+CUBE_BLOCK = OntologyNode(
+    "cube",
+    [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE, CUBIC],
+    non_inheritable_properties=[
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_CORE_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
+)
+subtype(CUBE_BLOCK, BLOCK)
+PYRAMID_BLOCK = OntologyNode(
+    "pyramid",
+    [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE, TRIANGULAR],
+    non_inheritable_properties=[
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_CORE_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
+)
+subtype(PYRAMID_BLOCK, BLOCK)
+SPHERICAL_BLOCK = OntologyNode(
+    "sphere",
+    [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE, SPHERICAL],
+    non_inheritable_properties=[
+        PHASE_3_CONCEPT,
+        PHASE_3_M4_CORE_CONCEPT,
+        PHASE_3_M4_STRETCH_CONCEPT,
+    ],
+)
+subtype(SPHERICAL_BLOCK, BLOCK)
+
+MUG = OntologyNode(
+    "mug",
+    [CAN_FILL_TEMPLATE_SLOT, PERSON_CAN_HAVE],
+    non_inheritable_properties=[PHASE_3_CONCEPT],
+)
+subtype(MUG, CONTAINER)
+
 NULL_NODE = OntologyNode("null")
 subtype(NULL_NODE, META_PROPERTY)
 
@@ -124,7 +166,9 @@ PHASE_3_CURRICULUM_OBJECTS = immutableset(
         BANANA,
         BALL,
         BOOK,
-        BLOCK,  # This is intended to have a shape modifier (Sphere, Cube, Triangular)
+        PYRAMID_BLOCK,
+        SPHERICAL_BLOCK,
+        CUBE_BLOCK,
         TABLE,
         CHAIR,
         SOFA,
@@ -156,6 +200,7 @@ _NULL_SCHEMA = ObjectStructuralSchema(
 GAILA_PHASE_3_STRUCUTRAL_SCHEMATA = [
     value for value in INTEGRATED_EXPERIMENT_STRUCTURAL_SCHEMATA
 ]
+
 GAILA_PHASE_3_STRUCUTRAL_SCHEMATA.extend(
     [
         (APPLE, _NULL_SCHEMA),
@@ -164,14 +209,18 @@ GAILA_PHASE_3_STRUCUTRAL_SCHEMATA.extend(
         (BALL, _BALL_SCHEMA),
         (BOOK, _BOOK_SCHEMA),
         (BLOCK, _NULL_SCHEMA),
+        (PYRAMID_BLOCK, _NULL_SCHEMA),
+        (CUBE_BLOCK, _NULL_SCHEMA),
+        (SPHERICAL_BLOCK, _NULL_SCHEMA),
         (TABLE, _TABLE_SCHEMA),
         (CHAIR, _CHAIR_SCHEMA),
         (SOFA, _NULL_SCHEMA),
         (BOX, _BOX_SCHEMA),
         (CUP, _CUP_SCHEMA),
+        (MUG, _NULL_SCHEMA),
         (FLOOR, _NULL_SCHEMA),
         (WINDOW, _NULL_SCHEMA),
-        (PAPER, _NULL_SCHEMA),
+        (PAPER, _PAPER_SCHEMA),
         (DESK, _NULL_SCHEMA),
         (TOY_TRUCK, _NULL_SCHEMA),
         (TOY_SEDAN, _NULL_SCHEMA),

--- a/tests/curriculum/phase3_curriculum_test.py
+++ b/tests/curriculum/phase3_curriculum_test.py
@@ -1,7 +1,13 @@
 import pytest
 
 from adam.curriculum.curriculum_utils import Phase3InstanceGroup
-from adam.curriculum.phase3_curriculum import Phase3OneObjectsCurriculum
+from adam.curriculum.phase3_curriculum import (
+    phase_3_one_objects_curriculum,
+    phase_3_m4_stretch_eval,
+    phase_3_one_core_objects_curriculum,
+    phase_3_one_stretch_objects_curriculum,
+    phase_3_m4_core_eval,
+)
 from adam.language_specific.english.english_language_generator import (
     GAILA_PHASE_3_LANGUAGE_GENERATOR,
 )
@@ -19,6 +25,15 @@ def curriculum_phase3_test(curriculum: Phase3InstanceGroup) -> None:
     "language_generator",
     [GAILA_PHASE_3_LANGUAGE_GENERATOR],
 )
-@pytest.mark.parametrize("curriculum", [Phase3OneObjectsCurriculum()])
+@pytest.mark.parametrize(
+    "curriculum",
+    [
+        phase_3_one_objects_curriculum,
+        phase_3_m4_stretch_eval,
+        phase_3_one_core_objects_curriculum,
+        phase_3_one_stretch_objects_curriculum,
+        phase_3_m4_core_eval,
+    ],
+)
 def test_phase3_curriculum(language_generator, curriculum):
     curriculum_phase3_test(curriculum(1, 5, language_generator))


### PR DESCRIPTION
This PR was used to generate the curriculum uploaded in #1063 

For easier use in other sections of code I've moved from using `ABC` to a `Protocol` -- A protocol makes more sense for the functionality I'm using it for to ensure that I can call any curriculum builder function with the same set of arguments and get an expected curriculum output. Not all curriculum builders will use all the arguments, but this is the minimum set used by all of them.