### PR TITLE
Update ID tracking to use ID from graph nodes if one exists

### DIFF
--- a/adam/experiment/observer.py
+++ b/adam/experiment/observer.py
@@ -880,9 +880,9 @@ class YAMLLogger(DescriptionObserver[SituationT, LinguisticDescriptionT, Percept
                     # to ensure the ID is unique, so we assume all semantic nodes in the scene could have an original ID
                     # and 'count' from there. This uniqueness guarantee could be improved, but it's not a problem
                     # to potentially have non-linear unique IDs.
-                    semantic_node.original_node_id
+                    semantic_node.original_node_id  # type: ignore
                     if semantic_node.original_node_id is not None
-                    else idx + len(predicted_scene_description.semantics_to_descriptions),  # type: ignore
+                    else idx + len(predicted_scene_description.semantics_to_descriptions),
                     semantic_node,
                     linguistic_description,
                     predicted_scene_description,

--- a/adam/experiment/observer.py
+++ b/adam/experiment/observer.py
@@ -874,7 +874,15 @@ class YAMLLogger(DescriptionObserver[SituationT, LinguisticDescriptionT, Percept
             semantic_node, linguistic_description = semantic_to_description
             output_dict[OUTPUT_LANGUAGE].append(
                 self._convert_to_output_format(
-                    semantic_node.original_node_id if semantic_node.original_node_id is not None else idx + len(predicted_scene_description.semantics_to_descriptions),  # type: ignore
+                    # If the semantic node has an alignment to an original perception node in the graph (e.g. an object
+                    # perception root) we want to use the original ID value to enable a matching between the produced
+                    # linguistic utterance and the identified object cluster. In the case no original ID exists we want
+                    # to ensure the ID is unique, so we assume all semantic nodes in the scene could have an original ID
+                    # and 'count' from there. This uniqueness guarantee could be improved, but it's not a problem
+                    # to potentially have non-linear unique IDs.
+                    semantic_node.original_node_id
+                    if semantic_node.original_node_id is not None
+                    else idx + len(predicted_scene_description.semantics_to_descriptions),  # type: ignore
                     semantic_node,
                     linguistic_description,
                     predicted_scene_description,

--- a/adam/experiment/observer.py
+++ b/adam/experiment/observer.py
@@ -874,7 +874,7 @@ class YAMLLogger(DescriptionObserver[SituationT, LinguisticDescriptionT, Percept
             semantic_node, linguistic_description = semantic_to_description
             output_dict[OUTPUT_LANGUAGE].append(
                 self._convert_to_output_format(
-                    idx,
+                    semantic_node.original_node_id if semantic_node.original_node_id is not None else idx + len(predicted_scene_description.semantics_to_descriptions),  # type: ignore
                     semantic_node,
                     linguistic_description,
                     predicted_scene_description,

--- a/adam/learner/learner_utils.py
+++ b/adam/learner/learner_utils.py
@@ -171,7 +171,7 @@ def pattern_match_to_semantic_node(
         and pattern_node in pattern.pattern_node_to_template_variable
     )
 
-    potential_root_node = get_root_object_cluster_perception(
+    potential_root_node = get_root_if_perception_is_object_cluster(
         match.graph_matched_against._graph,  # pylint: disable=protected-access
         set(match.matched_sub_graph),
     )
@@ -792,10 +792,12 @@ def get_slot_from_semantic_node(
     return slot
 
 
-def get_root_object_cluster_perception(
+def get_root_if_perception_is_object_cluster(
     graph: DiGraph, matched_subgraph_nodes: AbstractSet[PerceptionGraphNode]
 ) -> Optional[ObjectClusterNode]:
     """Get the root object cluster node from a graph given a subset of nodes which represent the object.
+
+    If the root object cluster does not exist this function will return none.
 
     Args:
         graph: A DiGraph of scene perception to process

--- a/adam/learner/learner_utils.py
+++ b/adam/learner/learner_utils.py
@@ -797,7 +797,9 @@ def get_root_if_perception_is_object_cluster(
 ) -> Optional[ObjectClusterNode]:
     """Get the root object cluster node from a graph given a subset of nodes which represent the object.
 
-    If the root object cluster does not exist this function will return none.
+        If a root object cluster node does not exist this function will return none. For example, this
+        happens when the passed nodes represent an action and not an object. It could also happen
+        if the nodes represent two separate objects.
 
     Args:
         graph: A DiGraph of scene perception to process

--- a/adam/learner/object_recognizer.py
+++ b/adam/learner/object_recognizer.py
@@ -367,13 +367,17 @@ class ObjectRecognizer:
                     )
                 if pattern_match:
                     cumulative_millis_in_successful_matches_ms += t.elapsed
-                    confidence = 1.0
+                    confidence, cluster_id = None, None
                     for graph_node in pattern_match.matched_sub_graph:
                         if isinstance(graph_node, StrokeGNNRecognitionNode):
                             confidence = graph_node.confidence
+                        if isinstance(graph_node, ObjectClusterNode):
+                            cluster_id = graph_node.cluster_id
 
                     matched_object_node = ObjectSemanticNode(
-                        concept, confidence=confidence
+                        concept,
+                        confidence=confidence if confidence else 1.0,
+                        original_node_id=cluster_id if cluster_id else None,
                     )
 
                     # We wrap the concept in a tuple because it could in theory be multiple tokens,

--- a/adam/perception/visual_perception.py
+++ b/adam/perception/visual_perception.py
@@ -156,9 +156,13 @@ class VisualPerceptionFrame(PerceptualRepresentationFrame):
                         weight=strokes_map["confidence_score"],
                     )
                 )
+
+            # Cluster ID is cleaned so that only the digit ID is displayed and not 'object'
             clusters.append(
                 ClusterPerception(
-                    cluster_id=cluster_map["object_name"],
+                    cluster_id="".join(
+                        char for char in cluster_map["object_name"] if char.isdigit()
+                    ),
                     viewpoint_id=cluster_map["viewpoint_id"],
                     sub_object_id=cluster_map.get("subobject_id", 0),
                     strokes=strokes,


### PR DESCRIPTION
Closes #1104 by tracking an original node ID via the detected semantic_node when applicable.