### PR TITLE
1113 rgbcolornodepredicate are slightly bugged

### DIFF
--- a/adam/perception/perception_graph_nodes.py
+++ b/adam/perception/perception_graph_nodes.py
@@ -115,9 +115,9 @@ class ContinuousNode(GraphNode):
 class RgbColorNode(GraphNode):
     """A node representing an RGB perception value."""
 
-    red: int = attrib(validator=in_(range(0, 255)))
-    green: int = attrib(validator=in_(range(0, 255)))
-    blue: int = attrib(validator=in_(range(0, 255)))
+    red: int = attrib(validator=in_(range(0, 256)))
+    green: int = attrib(validator=in_(range(0, 256)))
+    blue: int = attrib(validator=in_(range(0, 256)))
 
     def dot_label(self):
         return f"RgbColorNode({self})"

--- a/adam/perception/perception_graph_predicates.py
+++ b/adam/perception/perception_graph_predicates.py
@@ -371,9 +371,9 @@ class RgbColorPredicate(NodePredicate):
     Matches a node where the RGB value matches exactly.
     """
 
-    red: int = attrib(validator=in_(range(0, 255)))
-    green: int = attrib(validator=in_(range(0, 255)))
-    blue: int = attrib(validator=in_(range(0, 255)))
+    red: int = attrib(validator=in_(range(0, 256)))
+    green: int = attrib(validator=in_(range(0, 256)))
+    blue: int = attrib(validator=in_(range(0, 256)))
     _weight: float = attrib(
         kw_only=True, default=1.0, validator=instance_of(float), eq=False
     )

--- a/tests/perception/perception_graph_test.py
+++ b/tests/perception/perception_graph_test.py
@@ -60,7 +60,10 @@ from adam.perception.perception_graph import (
     RelationTypeIsPredicate,
     HAS_PROPERTY_LABEL,
 )
-from adam.perception.perception_graph_nodes import ContinuousNode
+from adam.perception.perception_graph_nodes import (
+    ContinuousNode,
+    RgbColorNode
+)
 from adam.perception.perception_graph_predicates import (
     DistributionalContinuousPredicate,
     AnyObjectPredicate,
@@ -917,6 +920,12 @@ def test_simulated_one_object_graph():
     result = any(matcher.matches(use_lookahead_pruning=False))
     if not result:
         return False
+
+
+def test_rgb_color_node():
+    assert RgbColorNode(red=0, blue=0, green=0, weight=1.0)
+    assert RgbColorNode(red=255, blue=255, green=255, weight=0.0)
+
 
 
 def _simulated_graph_with_continuous_feature(*, feature_name: str, observed_value: float):

--- a/tests/perception/perception_graph_test.py
+++ b/tests/perception/perception_graph_test.py
@@ -67,6 +67,7 @@ from adam.perception.perception_graph_nodes import (
 from adam.perception.perception_graph_predicates import (
     DistributionalContinuousPredicate,
     AnyObjectPredicate,
+    RgbColorPredicate
 )
 from adam.perception.visual_perception import VisualPerceptionFrame
 from adam.random_utils import RandomChooser
@@ -926,6 +927,13 @@ def test_rgb_color_node():
     assert RgbColorNode(red=0, blue=0, green=0, weight=1.0)
     assert RgbColorNode(red=255, blue=255, green=255, weight=0.0)
 
+def test_rgb_color_predicate():
+    assert RgbColorPredicate(red=0, blue=0, green=0, weight=1.0)
+    assert RgbColorPredicate(red=255, blue=255, green=255, weight=0.0)
+
+def test_rgb_color_perception():
+    assert RgbColorPerception(red=0, blue=0, green=0)
+    assert RgbColorPerception(red=255, blue=255, green=255)
 
 
 def _simulated_graph_with_continuous_feature(*, feature_name: str, observed_value: float):

--- a/tests/perception/perception_graph_test.py
+++ b/tests/perception/perception_graph_test.py
@@ -920,19 +920,19 @@ def test_simulated_one_object_graph():
         return False
 
 
-def test_rgb_color_node():
-    assert RgbColorNode(red=0, blue=0, green=0, weight=1.0)
-    assert RgbColorNode(red=255, blue=255, green=255, weight=0.0)
+def test_rgb_color_node_accepts_valid_values():
+    RgbColorNode(red=0, blue=0, green=0, weight=1.0)
+    RgbColorNode(red=255, blue=255, green=255, weight=0.0)
 
 
-def test_rgb_color_predicate():
-    assert RgbColorPredicate(red=0, blue=0, green=0, weight=1.0)
-    assert RgbColorPredicate(red=255, blue=255, green=255, weight=0.0)
+def test_rgb_color_predicate_accepts_valid_values():
+    RgbColorPredicate(red=0, blue=0, green=0, weight=1.0)
+    RgbColorPredicate(red=255, blue=255, green=255, weight=0.0)
 
 
-def test_rgb_color_perception():
-    assert RgbColorPerception(red=0, blue=0, green=0)
-    assert RgbColorPerception(red=255, blue=255, green=255)
+def test_rgb_color_perception_accepts_valid_values():
+    RgbColorPerception(red=0, blue=0, green=0)
+    RgbColorPerception(red=255, blue=255, green=255)
 
 
 def _simulated_graph_with_continuous_feature(*, feature_name: str, observed_value: float):

--- a/tests/perception/perception_graph_test.py
+++ b/tests/perception/perception_graph_test.py
@@ -60,14 +60,11 @@ from adam.perception.perception_graph import (
     RelationTypeIsPredicate,
     HAS_PROPERTY_LABEL,
 )
-from adam.perception.perception_graph_nodes import (
-    ContinuousNode,
-    RgbColorNode
-)
+from adam.perception.perception_graph_nodes import ContinuousNode, RgbColorNode
 from adam.perception.perception_graph_predicates import (
     DistributionalContinuousPredicate,
     AnyObjectPredicate,
-    RgbColorPredicate
+    RgbColorPredicate,
 )
 from adam.perception.visual_perception import VisualPerceptionFrame
 from adam.random_utils import RandomChooser
@@ -927,9 +924,11 @@ def test_rgb_color_node():
     assert RgbColorNode(red=0, blue=0, green=0, weight=1.0)
     assert RgbColorNode(red=255, blue=255, green=255, weight=0.0)
 
+
 def test_rgb_color_predicate():
     assert RgbColorPredicate(red=0, blue=0, green=0, weight=1.0)
     assert RgbColorPredicate(red=255, blue=255, green=255, weight=0.0)
+
 
 def test_rgb_color_perception():
     assert RgbColorPerception(red=0, blue=0, green=0)


### PR DESCRIPTION
Fairly quick fix, just altered upper limit of ranges in RGB Nodes/Predicates to 256 instead of 255.