### PR TITLE
Set observers to only log with log_learner_state=True

### DIFF
--- a/adam/experiment/__init__.py
+++ b/adam/experiment/__init__.py
@@ -408,7 +408,8 @@ def execute_experiment(
                     pickle.dump(
                         observers_holder,
                         open(
-                            observer_path / f"observers_state_at_{str(num_observations)}.pkl",
+                            observer_path
+                            / f"observers_state_at_{str(num_observations)}.pkl",
                             "wb",
                         ),
                         pickle.HIGHEST_PROTOCOL,


### PR DESCRIPTION
Just added an indent to check if `log_learner_state=True` before logging observers