### PR TITLE
Move all labels to dot_label function

### DIFF
--- a/adam/axis.py
+++ b/adam/axis.py
@@ -14,6 +14,9 @@ class GeonAxis:
     def copy(self) -> "GeonAxis":
         return evolve(self)
 
+    def dot_label(self) -> str:
+        return f"axis:{self.debug_name}"
+
     def __repr__(self) -> str:
         return (
             f"{self.debug_name}"

--- a/adam/geon.py
+++ b/adam/geon.py
@@ -28,6 +28,9 @@ class CrossSection:
     )
     curved: bool = attrib(validator=instance_of(bool), default=False, kw_only=True)
 
+    def dot_label(self) -> str:
+        return str(self)
+
     def __repr__(self) -> str:
         return (
             f"[{sign(self.has_reflective_symmetry)}reflect-sym, "
@@ -84,6 +87,9 @@ class Geon(HasAxes):
     @generating_axis.default
     def _init_primary_axis(self) -> GeonAxis:
         return self.axes.primary_axis
+
+    def dot_label(self) -> str:
+        return str(self.cross_section) + str(self.cross_section_size)
 
 
 class MaybeHasGeon(Protocol):

--- a/adam/ontology/__init__.py
+++ b/adam/ontology/__init__.py
@@ -43,6 +43,9 @@ class OntologyNode:
     which should not be inherited by its children.
     """
 
+    def dot_label(self) -> str:
+        return self.handle
+
     def __repr__(self) -> str:
         if self.inheritable_properties:
             local_properties = ",".join(

--- a/adam/ontology/phase1_spatial_relations.py
+++ b/adam/ontology/phase1_spatial_relations.py
@@ -237,6 +237,9 @@ class Region(Generic[ReferenceObjectT]):
             "A region must have either a distance or direction specified.",
         )
 
+    def dot_label(self) -> str:
+        return f"reg:{self}"
+
     def __repr__(self) -> str:
         parts = [str(self.reference_object)]
         if self.distance:
@@ -249,6 +252,10 @@ class Region(Generic[ReferenceObjectT]):
 @attrs(frozen=True, slots=True)
 class PathOperator:
     name: str = attrib(validator=instance_of(str))
+
+    def dot_label(self) -> str:
+        # regions do have content but we express those as edges to other nodes
+        return self.name
 
 
 VIA = PathOperator("via")
@@ -413,6 +420,9 @@ class SpatialPath(Generic[ReferenceObjectT]):
             else other_path.orientation_changed,
             properties=chain(self.properties, other_path.properties),
         )
+
+    def dot_label(self) -> str:
+        return "path"
 
     # @reference_destination_object.default
     # def _assume_dest_is_source(self) -> Union[ReferenceObjectT, Region[ReferenceObjectT]]:

--- a/adam/perception/__init__.py
+++ b/adam/perception/__init__.py
@@ -59,6 +59,10 @@ class ObjectPerception(HasAxes, MaybeHasGeon):
                 "its axes must be specified explicitly"
             )
 
+    def dot_label(self) -> str:
+        # object perceptions have no content, so they are blank nodes
+        return self.debug_handle
+
     def __repr__(self) -> str:
         return self.debug_handle
 

--- a/adam/perception/developmental_primitive_perception.py
+++ b/adam/perception/developmental_primitive_perception.py
@@ -113,6 +113,9 @@ class RgbColorPerception:
     def hex(self) -> str:
         return f"#{self.red:02x}{self.green:02x}{self.blue:02x}"
 
+    def dot_label(self) -> str:
+        return self.hex
+
     def __repr__(self) -> str:
         """
         We represent colors by hex strings because these are easy to visualize using web tools.

--- a/adam/perception/perception_graph.py
+++ b/adam/perception/perception_graph.py
@@ -575,48 +575,15 @@ class PerceptionGraph(PerceptionGraphProtocol, Sized, Iterable[PerceptionGraphNo
 
         if perception_node in replace_node_labels:
             label = replace_node_labels[perception_node]
-        elif isinstance(unwrapped_perception_node, ObjectPerception):
-            # object perceptions have no content, so they are blank nodes
-            label = unwrapped_perception_node.debug_handle
-        elif isinstance(unwrapped_perception_node, Region):
-            # regions do have content but we express those as edges to other nodes
-            label = f"reg:{unwrapped_perception_node}"
-        elif isinstance(unwrapped_perception_node, GeonAxis):
-            label = f"axis:{unwrapped_perception_node.debug_name}"
-        elif isinstance(unwrapped_perception_node, RgbColorPerception):
-            label = unwrapped_perception_node.hex
-        elif isinstance(unwrapped_perception_node, OntologyNode):
-            label = unwrapped_perception_node.handle
-        elif isinstance(unwrapped_perception_node, Geon):
-            label = str(unwrapped_perception_node.cross_section) + str(
-                unwrapped_perception_node.cross_section_size
-            )
-        elif isinstance(unwrapped_perception_node, CrossSection):
-            label = str(unwrapped_perception_node)
-        elif isinstance(unwrapped_perception_node, ObjectSemanticNode):
-            label = " ".join(unwrapped_perception_node.concept.debug_string)
-        elif isinstance(unwrapped_perception_node, SpatialPath):
-            label = "path"
-        elif isinstance(unwrapped_perception_node, PathOperator):
-            label = unwrapped_perception_node.name
-        elif isinstance(unwrapped_perception_node, ObjectClusterNode):
-            label = f"Object Cluster {unwrapped_perception_node.cluster_id} | View: {unwrapped_perception_node.viewpoint_id}"
-        elif isinstance(unwrapped_perception_node, ObjectStroke):
-            label = f"Stroke: [{', '.join(str(point) for point in unwrapped_perception_node.normalized_coordinates)}]"
-        elif isinstance(unwrapped_perception_node, TrajectoryRecognitionNode):
-            label = f"Trajectory Recognition: {unwrapped_perception_node.action_recognized} ({unwrapped_perception_node.confidence})"
-        elif isinstance(unwrapped_perception_node, JointPointNode):
-            label = f"JointPointNode ({unwrapped_perception_node.joint_index}.{unwrapped_perception_node.temporal_index}) world: {unwrapped_perception_node.world_coord}"
-        elif isinstance(
-            unwrapped_perception_node,
-            (ContinuousNode, CategoricalNode, RgbColorNode, StrokeGNNRecognitionNode),
-        ):
-            label = str(unwrapped_perception_node)
         else:
-            raise RuntimeError(
-                f"Do not know how to perception node render node "
-                f"{unwrapped_perception_node} with dot"
-            )
+            try:
+                label = unwrapped_perception_node.dot_label()
+            except AttributeError as exc:
+                # old else branch error
+                raise RuntimeError(
+                    f"Do not know how to perception node render node "
+                    f"{unwrapped_perception_node} with dot"
+                ) from exc
 
         # if we are rendering a pattern which partially matched against a graph,
         # the user can supply IDs for those nodes which matched to show the correspondence.

--- a/adam/perception/perception_graph_nodes.py
+++ b/adam/perception/perception_graph_nodes.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Union, Tuple, Any, Optional
 
 from attr import attrs, attrib
@@ -27,6 +27,11 @@ class ObjectStroke:
         validator=deep_iterable(instance_of(Point)), converter=_to_immutableset
     )
 
+    def dot_label(self) -> str:
+        return (
+            f"Stroke: [{', '.join(str(point) for point in self.normalized_coordinates)}]"
+        )
+
     def __str__(self) -> str:
         return f"Stroke[{', '.join(f'({point.x:.2f}, {point.y:.2f})' for point in self.normalized_coordinates)}]"
 
@@ -37,6 +42,10 @@ class GraphNode(ABC):
     """Super-class for all perception graph nodes, useful for types."""
 
     weight: float = attrib(validator=instance_of(float))
+
+    @abstractmethod
+    def dot_label(self) -> str:
+        raise NotImplementedError()
 
 
 PerceptionGraphNode = Union[

--- a/adam/semantics.py
+++ b/adam/semantics.py
@@ -85,6 +85,9 @@ class SemanticNode(Protocol):
     confidence: float
     original_node_id: Optional[str] = None
 
+    def dot_label(self) -> str:
+        return f"Semantic Node: {self.concept.debug_string}"
+
     @staticmethod
     def for_concepts_and_arguments(
         concept: Concept,
@@ -134,6 +137,9 @@ class ObjectSemanticNode(SemanticNode):
     original_node_id: Optional[str] = attrib(
         default=None, validator=optional(instance_of(str))
     )
+
+    def dot_label(self) -> str:
+        return self.concept.debug_string
 
     # def __attrs_post_init__(self) -> None:
     #     for template in self.templates:


### PR DESCRIPTION
Closes #1134

In order to eliminate the need for a large `if..elif..else` chain, we define a `dot_label()` function for all classes which can be represented in `_to_dot_node()`