### PR TITLE
1156 downsampling experiment

### DIFF
--- a/adam/curriculum/curriculum_from_files.py
+++ b/adam/curriculum/curriculum_from_files.py
@@ -31,9 +31,13 @@ PHASE_3_TRAINING_CURRICULUM_OPTIONS = [
     "m5_actions",
     "m5_actions_person_only",
     "m6_objects_downsampled_2pertype_post_gnn",
-    "m6_objects_downsampled_100 pertype_post_gnn",
+    "m6_objects_downsampled_10pertype_post_gnn",
     "m5_objects_v0_with_mugs_post_gnn",
-    "m6_unknown_objects"
+    "m6_unknown_objects",
+    "m6_objects_v0_with_mugs_post_gnn_top2",
+    "m6_objects_v0_with_mugs_post_gnn_top3",
+    "m6_objects_v0_with_mugs_post_gnn_top4",
+    "m6_objects_v0_with_mugs_post_gnn_top5",
 ]
 
 PHASE_3_TESTING_CURRICULUM_OPTIONS = [
@@ -47,7 +51,11 @@ PHASE_3_TESTING_CURRICULUM_OPTIONS = [
     "m5_objects_v0_with_mugs_eval_2pertype_post_gnn",
     "m5_objects_v0_with_mugs_eval_10pertype_post_gnn",
     "m5_objects_v0_with_mugs_eval_post_gnn",
-    "m6_unknown_objects_eval"
+    "m6_unknown_objects_eval",
+    "m6_objects_v0_with_mugs_eval_post_gnn_top2",
+    "m6_objects_v0_with_mugs_eval_post_gnn_top3",
+    "m6_objects_v0_with_mugs_eval_post_gnn_top4",
+    "m6_objects_v0_with_mugs_eval_post_gnn_top5",
 ]
 
 TRAINING_CUR = "training"

--- a/adam/curriculum/curriculum_from_files.py
+++ b/adam/curriculum/curriculum_from_files.py
@@ -33,6 +33,7 @@ PHASE_3_TRAINING_CURRICULUM_OPTIONS = [
     "m6_objects_downsampled_2pertype_post_gnn",
     "m6_objects_downsampled_100 pertype_post_gnn",
     "m5_objects_v0_with_mugs_post_gnn",
+    "m6_unknown_objects"
 ]
 
 PHASE_3_TESTING_CURRICULUM_OPTIONS = [
@@ -46,6 +47,7 @@ PHASE_3_TESTING_CURRICULUM_OPTIONS = [
     "m5_objects_v0_with_mugs_eval_2pertype_post_gnn",
     "m5_objects_v0_with_mugs_eval_10pertype_post_gnn",
     "m5_objects_v0_with_mugs_eval_post_gnn",
+    "m6_unknown_objects_eval"
 ]
 
 TRAINING_CUR = "training"

--- a/adam/curriculum/curriculum_from_files.py
+++ b/adam/curriculum/curriculum_from_files.py
@@ -30,6 +30,9 @@ PHASE_3_TRAINING_CURRICULUM_OPTIONS = [
     "m5_objects_v0_with_mugs",
     "m5_actions",
     "m5_actions_person_only",
+    "m6_objects_downsampled_2pertype_post_gnn",
+    "m6_objects_downsampled_100 pertype_post_gnn",
+    "m5_objects_v0_with_mugs_post_gnn",
 ]
 
 PHASE_3_TESTING_CURRICULUM_OPTIONS = [
@@ -40,6 +43,9 @@ PHASE_3_TESTING_CURRICULUM_OPTIONS = [
     "m5_objects_v0_with_mugs_eval",
     "m5_actions_eval",
     "m5_actions_person_only_eval",
+    "m5_objects_v0_with_mugs_eval_2pertype_post_gnn",
+    "m5_objects_v0_with_mugs_eval_10pertype_post_gnn",
+    "m5_objects_v0_with_mugs_eval_post_gnn",
 ]
 
 TRAINING_CUR = "training"

--- a/adam/perception/visual_perception.py
+++ b/adam/perception/visual_perception.py
@@ -156,6 +156,15 @@ class VisualPerceptionFrame(PerceptualRepresentationFrame):
                         weight=strokes_map["confidence_score"],
                     )
                 )
+            if "concept_names" in strokes_map:
+                for concept_name in strokes_map["concept_names"]:
+                    properties.append(
+                        StrokeGNNRecognitionNode(
+                            object_recognized=concept_name,
+                            confidence=strokes_map["confidence_score"],
+                            weight=strokes_map["confidence_score"],
+                        )
+                    )
 
             # Cluster ID is cleaned so that only the digit ID is displayed and not 'object'
             clusters.append(

--- a/adam_preprocessing/shape_stroke_graph_inference.py
+++ b/adam_preprocessing/shape_stroke_graph_inference.py
@@ -137,7 +137,7 @@ def main():
             if len(feature_yamls) == 1:
                 # Load features, update them, then save
                 with open(
-                    input_situation_dir / feature_yamls[0], encoding="utf-8"
+                    feature_yamls[0], encoding="utf-8"
                 ) as feature_yaml_in:
                     features = yaml.safe_load(feature_yaml_in)
 

--- a/adam_preprocessing/shape_stroke_graph_learner.py
+++ b/adam_preprocessing/shape_stroke_graph_learner.py
@@ -161,8 +161,7 @@ def main():
         logging.info(
             "{}, loss: {:.4e}, acc: {}, test acc :{}".format(
                 step, train_loss.item(), acc, test_acc
-            ),
-            flush=True,
+            )
         )
     logging.info("Best test acc is {}".format(best_acc))
     logging.info(f"Saving model state dict to {args.save_model_to}")

--- a/adam_preprocessing/utils.py
+++ b/adam_preprocessing/utils.py
@@ -66,7 +66,7 @@ def get_stroke_data(
         feature_yamls = sorted(situation_dir.glob("feature*"))
         if len(feature_yamls) == 1:
             with open(
-                situation_dir / feature_yamls[0], encoding="utf-8"
+                feature_yamls[0], encoding="utf-8"
             ) as feature_yaml_in:
                 features = yaml.safe_load(feature_yaml_in)
 

--- a/parameters/experiments/p3/m5_objects_v0_with_mugs_full_subset.params
+++ b/parameters/experiments/p3/m5_objects_v0_with_mugs_full_subset.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m5_objects_v0_with_mugs_post_gnn"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m5_objects_v0_with_mugs_eval_post_gnn"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m5_objects_v0_with_mugs_full"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_10pertype_subset.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_10pertype_subset.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_downsampled_10pertype_post_gnn"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m5_objects_v0_with_mugs_eval_10pertype_post_gnn"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_objects_downsampled_10pertype"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_2pertype_subset.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_2pertype_subset.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_downsampled_2pertype_post_gnn"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m5_objects_v0_with_mugs_eval_2pertype_post_gnn"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_objects_downsampled_2pertype"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_top2.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_top2.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_v0_with_mugs_post_gnn_top2"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_objects_v0_with_mugs_eval_post_gnn_top2"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_unknown_objects"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_top3.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_top3.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_v0_with_mugs_post_gnn_top3"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_objects_v0_with_mugs_eval_post_gnn_top3"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_unknown_objects"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_top4.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_top4.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_v0_with_mugs_post_gnn_top4"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_objects_v0_with_mugs_eval_post_gnn_top4"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_unknown_objects"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_objects_v0_with_mugs_top5.params
+++ b/parameters/experiments/p3/m6_objects_v0_with_mugs_top5.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_objects_v0_with_mugs_post_gnn_top5"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_objects_v0_with_mugs_eval_post_gnn_top5"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_unknown_objects"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p3/m6_unknown_objects.params
+++ b/parameters/experiments/p3/m6_unknown_objects.params
@@ -1,0 +1,60 @@
+_includes:
+   - "../../root.params"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+ learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_unknown_objects"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_unknown_objects_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_unknown_objects"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/scripts/GNN_topk_analysis.py
+++ b/scripts/GNN_topk_analysis.py
@@ -1,0 +1,88 @@
+import argparse
+import logging
+from os import makedirs
+from pathlib import Path
+from shutil import rmtree, copytree
+from typing import Mapping, Sequence
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sn
+import yaml
+
+def parse_in_domain_objects(input_dir: Path) -> Sequence:
+    in_domain_objects = set()
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'description.yaml', encoding="utf-8") as description_file:
+            description_yaml = yaml.safe_load(description_file)
+            object = description_yaml['language'].rsplit()[-1]
+            in_domain_objects.add(object)
+    return sorted(in_domain_objects)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Get confusion matrix for GNN decode"
+    )
+    parser.add_argument('--input-dir', type=Path, help="Inpuut curriculum directory to read GNN decodes from")
+    parser.add_argument('--output-dir', type=Path, help="Output directory to write top GNN decode matrix and data to")
+    parser.add_argument(
+        "-f", "--force",
+        action='store_true',
+        required=False,
+        help='Force overwrite of target directory. By default, the script exits with an error if there already exists '
+             'a directory at the target destination.'
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    input_dir: Path = args.input_dir
+    output_dir: Path = args.output_dir
+    force_overwrite: bool = args.force
+
+    if not input_dir.exists():
+        logging.warning("Input directory does not exist")
+        raise FileNotFoundError(str(input_dir))
+
+    if output_dir.is_dir():
+        if not force_overwrite:
+            logging.warning("There already exists a directory in the target location")
+            raise FileExistsError(str(output_dir))
+    else:
+        makedirs(output_dir)
+
+    in_domain_objects = parse_in_domain_objects(input_dir)
+    object_counts = {in_domain_object: 0 for in_domain_object in in_domain_objects}
+    gnn_rank_matrix = [[0 for _ in range(len(in_domain_objects))] for _ in range(len(in_domain_objects))]
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'description.yaml', encoding="utf-8") as description_file:
+            description_yaml = yaml.safe_load(description_file)
+            expected_object = description_yaml['language'].rsplit()[-1]
+            object_counts[expected_object] += 1
+        with open(feature_file_path / 'feature.yaml', encoding="utf-8") as feature_file:
+            feature_yaml = yaml.safe_load(feature_file)
+            gnn_objects = feature_yaml['objects'][0]['stroke_graph']['concept_names']
+            for i in range(len(gnn_objects)):
+                gnn_object = gnn_objects[i]
+                if gnn_object == 'small_single_mug': gnn_object = 'mug'
+                gnn_rank_matrix[in_domain_objects.index(expected_object)][in_domain_objects.index(gnn_object)] += len(gnn_objects) - i
+    for object_id in range(len(gnn_rank_matrix)):
+        gnn_rank_matrix[object_id] = [label_count / object_counts[in_domain_objects[object_id]] for label_count in arr[object_id]]
+    df = pd.DataFrame(gnn_rank_matrix, in_domain_objects, in_domain_objects)
+    sn.set(font_scale=0.9)
+    sn.color_palette('colorblind')
+    sn.set_context('paper')
+    heatmap = sn.heatmap(df, annot=True, cbar=False)
+    heatmap.set_xticklabels(labels=in_domain_objects, rotation=45, horizontalalignment='right')
+    plt.xlabel('GNN Object Label Weight')
+    plt.ylabel('True Object Label')
+    plt.title('Top GNN Predictions per Object', size=18)
+    plt.tight_layout()
+
+    plt.savefig(output_dir / 'top_gnn_vs_description.png')
+    df.to_csv(output_dir / 'top_gnn_vs_description.csv')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/GNN_vs_expected.py
+++ b/scripts/GNN_vs_expected.py
@@ -1,0 +1,84 @@
+import argparse
+import logging
+from os import makedirs
+from pathlib import Path
+from shutil import rmtree, copytree
+from typing import Mapping, Sequence
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sn
+import yaml
+
+def parse_in_domain_objects(input_dir: Path) -> Sequence:
+    in_domain_objects = set()
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'description.yaml', encoding="utf-8") as description_file:
+            description_yaml = yaml.safe_load(description_file)
+            object = description_yaml['language'].rsplit()[-1]
+            in_domain_objects.add(object)
+    return sorted(in_domain_objects)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Get confusion matrix for GNN decode"
+    )
+    parser.add_argument('--input-dir', type=Path, help="Curriculum directory to read GNN decodes from")
+    parser.add_argument('--output-dir', type=Path, help="Directory to output confusion matrix and associated data to")
+    parser.add_argument(
+        "-f", "--force",
+        action='store_true',
+        required=False,
+        help='Force overwrite of target directory. By default, the script exits with an error if there already exists '
+             'a directory at the target destination.'
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    input_dir: Path = args.input_dir
+    output_dir: Path = args.output_dir
+    force_overwrite: bool = args.force
+
+    if not input_dir.exists():
+        logging.warning("Input directory does not exist")
+        raise FileNotFoundError(str(input_dir))
+
+    if output_dir.is_dir():
+        if not force_overwrite:
+            logging.warning("There already exists a directory in the target location")
+            raise FileExistsError(str(output_dir))
+    else:
+        makedirs(output_dir)
+
+    in_domain_objects = parse_in_domain_objects(input_dir)
+    confusion_matrix = [[0 for _ in range(len(in_domain_objects))] for _ in range(len(in_domain_objects))]
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'description.yaml', encoding="utf-8") as description_file:
+            description_yaml = yaml.safe_load(description_file)
+            expected_object = description_yaml['language'].rsplit()[-1]
+        with open(feature_file_path / 'feature.yaml', encoding="utf-8") as feature_file:
+            feature_yaml = yaml.safe_load(feature_file)
+            gnn_object = feature_yaml['objects'][0]['stroke_graph']['concept_name']
+            if gnn_object == 'small_single_mug': gnn_object = 'mug'
+        print(expected_object, gnn_object)
+        confusion_matrix[in_domain_objects.index(expected_object)][in_domain_objects.index(gnn_object)] += 1
+
+    df = pd.DataFrame(confusion_matrix, in_domain_objects, in_domain_objects)
+    sn.set(font_scale=0.9)
+    sn.color_palette('colorblind')
+    sn.set_context('paper')
+    heatmap = sn.heatmap(df, annot=True, cbar=False)
+    heatmap.set_xticklabels(labels=in_domain_objects, rotation=45, horizontalalignment='right')
+    plt.xlabel('GNN Object Prediction')
+    plt.ylabel('Expected Object Label')
+    plt.title('GNN Decode vs Expected Label', size=18)
+    plt.tight_layout()
+
+    plt.savefig(output_dir / 'gnn_vs_description.png')
+    df.to_csv(output_dir / 'gnn_vs_description.csv')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/adam_decode_vs_expected.py
+++ b/scripts/adam_decode_vs_expected.py
@@ -1,0 +1,92 @@
+import argparse
+import logging
+from os import makedirs
+from pathlib import Path
+from shutil import rmtree, copytree
+from typing import Mapping, Sequence
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sn
+import yaml
+
+def parse_in_domain_objects(input_dir: Path) -> Sequence:
+    in_domain_objects = set()
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'post_decode.yaml', encoding="utf-8") as description_file:
+            description_yaml = yaml.safe_load(description_file)
+            object = description_yaml['gold_language'].rsplit()[-1]
+            in_domain_objects.add(object)
+    return sorted(in_domain_objects)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Get confusion matrix for GNN decode"
+    )
+    parser.add_argument('--input-dir', type=Path, help="Curriculum directory with ADAM decode files to read from")
+    parser.add_argument('--output-dir', type=Path, help="Target directory to output confusion matrix and associated data to")
+    parser.add_argument(
+        "-f", "--force",
+        action='store_true',
+        required=False,
+        help='Force overwrite of target directory. By default, the script exits with an error if there already exists '
+             'a directory at the target destination.'
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    input_dir: Path = args.input_dir
+    output_dir: Path = args.output_dir
+    force_overwrite: bool = args.force
+
+    if not input_dir.exists():
+        logging.warning("Input directory does not exist")
+        raise FileNotFoundError(str(input_dir))
+
+    if output_dir.is_dir():
+        if not force_overwrite:
+            logging.warning("There already exists a directory in the target location")
+            raise FileExistsError(str(output_dir))
+    else:
+        makedirs(output_dir)
+
+    in_domain_objects=parse_in_domain_objects(input_dir)
+    confusion_matrix = [[0 for _ in range(len(in_domain_objects) + 1)] for _ in range(len(in_domain_objects))]
+    none_count = 0
+    correct_count = 0
+    for feature_file_path in sorted(input_dir.glob("situation*")):
+        with open(feature_file_path / 'post_decode.yaml', encoding="utf-8") as decode_file:
+            decode_yaml = yaml.safe_load(decode_file)
+            expected_object = decode_yaml['gold_language'].rsplit()[-1]
+            if len(decode_yaml['output_language']) > 0:
+                gnn_object = decode_yaml['output_language'][0]['raw_text'].rsplit()[-1]
+                print(expected_object, gnn_object)
+                confusion_matrix[in_domain_objects.index(expected_object)][in_domain_objects.index(gnn_object)] += 1
+                if expected_object == gnn_object:
+                    correct_count += 1
+            else:
+                none_count += 1
+                confusion_matrix[in_domain_objects.index(expected_object)][-1] += 1
+
+
+    df = pd.DataFrame(confusion_matrix, in_domain_objects, in_domain_objects + ['No Label'])
+    sn.set(font_scale=0.9)
+    sn.color_palette('colorblind')
+    sn.set_context('paper')
+    heatmap = sn.heatmap(df, annot=True, cbar=False)
+    heatmap.set_xticklabels(labels=in_domain_objects + ['No Label'], rotation=45, horizontalalignment='right')
+    plt.xlabel('ADAM Output Language')
+    plt.ylabel('Expected Object Label')
+    plt.title('Adam Decode vs Expected Label', size=18)
+    plt.tight_layout()
+
+    plt.savefig(output_dir / 'adam_decode_vs_description.png')
+    df.to_csv(output_dir / 'adam_decode_vs_description.csv')
+    print("Correctly labeled:", correct_count)
+    print("% Correct:", correct_count/sum(sum(i) for i in arr))
+    print("Objects with no label:", none_count)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #1156 and #1157 

Performed both within the same branch because I needed similar scripts for both for visualizing GNN/ADAM performance between different experiments.

There are 4 important features added here:

1. Script to generate confusion matrix for GNN outputs given an input curriculum
2. Script to generate confusion matrix for ADAM outputs given an input curriculum
3. Script to generate confusion matrix for top GNN outputs per object given an input curriculum
4. Added functionality to
   - Retrieve top `k` GNN decodes per object from `shape_stroke_graph_inference.py`
   - Add each of the top `k` decodes as a node in ADAM and handle accordingly.

Aside from those, most of the new additions here are just adding parameter files which I used the preexisting downsample/unknown object generation scripts to create the curricula for.