### PR TITLE
In README: switch working directories

### DIFF
--- a/adam_preprocessing/README.md
+++ b/adam_preprocessing/README.md
@@ -20,7 +20,8 @@ Assuming you want to run stroke extraction, be sure to install the following two
 To run stroke extraction on the M5 objects with mugs train curriculum, run:
 
 ```bash
-python adam_preprocessing/shape_stroke_extraction.py \
+cd adam_preprocessing
+python shape_stroke_extraction.py \
   "data/curriculum/train/m5_objects_v0_with_mugs" \
   "path/to/outputs"
 ```


### PR DESCRIPTION
In my experience, you need to switch your working directory to `adam_preprocessing` in order to allow the `ske.m` file to be available to the MATLAB backend. Not sure if there's some other way to achieve this that I'm missing.