### PR TITLE
Pipeline script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ You can check out our papers to read more about the system and to cite our work:
    # if you want to view experiment results in the UI, you must point adam_experiment_root to
    # %adam_root%/data, otherwise any directory is fine:
    adam_experiment_root: %adam_root%/data
+   # if you want to run the full pipeline which includes preprocessing:
+   stroke_python_root: /path/to/anaconda3/envs/adam_preprocessing
+   # for the segmentation part of the pipeline (ISI: 500{1,2,3} are in use):
+   segmentation_api_port: XXXX
 
    conda_environment: adam
    conda_base_path: PATH_TO_ANACONDA_DIRECTORY

--- a/adam/experiment/run_pipeline.py
+++ b/adam/experiment/run_pipeline.py
@@ -1,0 +1,644 @@
+"""
+A script intended to run the entire M3 pipeline.
+
+Note that this script does not take care of starting the object segmentation server. You have to do
+that separately.
+
+Note also that this writes to then reads from a params file for ADAM. If you run this again with the
+same params file name while a job is running, you will overwrite the old parameters! So be careful.
+"""
+import atexit
+from datetime import datetime
+from io import StringIO
+from locale import getpreferredencoding
+import logging
+import os
+from os import getenv
+from pathlib import Path
+import shlex
+from shutil import copytree
+from subprocess import run, CalledProcessError
+from typing import List, Mapping, NewType, Optional, Sequence
+
+import yaml
+
+from vistautils.parameters_only_entrypoint import parameters_only_entry_point
+from vistautils.parameters import Parameters, ParameterError
+
+logger = logging.getLogger(__name__)
+
+
+SlurmJobID = NewType("SlurmJobID", str)
+Email = NewType("Email", str)
+MailType = NewType("MailType", str)
+
+slurm_jobs_scheduled: List[SlurmJobID] = []
+
+
+def stop_slurm_jobs():
+    """
+    Exit handler to clean up Slurm jobs.
+    """
+    for job_id in slurm_jobs_scheduled:
+        logger.info("Canceling previously scheduled job %s...", job_id)
+        cancel_command = ["scancel", str(job_id)]
+        print(" ".join(shlex.quote(part) for part in cancel_command))
+        run(cancel_command, check=False)
+
+
+def build_sbatch_command(
+    script_path: Path,
+    *,
+    dependencies: Sequence[SlurmJobID] = (),
+    job_name: Optional[str] = None,
+    log_dir: Optional[Path] = None,
+    email: Optional[Email] = None,
+    mail_types: Sequence[MailType] = (),
+    extra_sbatch_args: Sequence[str] = (),
+    script_args: Sequence[str],
+) -> Sequence[str]:
+    """
+    Construct a Slurm command to run the given sbatch script in a parseable way.
+
+    This returns a sequence of commandline arguments that can be passed directly to
+    subprocess.run(). This function passes --parsable to sbatch to force the output to an easily
+    machine-readable format; note however that even with this flag errors are printed in the usual
+    way.
+
+    Parameters:
+        script_path: The path to the Slurm/sbatch script to run.
+        dependencies:
+            A sequence of Slurm job IDs this job should depend on. This job will only run after
+            every dependency has completed successfully.
+        job_name: A custom name to use for the job.
+        log_dir: A directory in which to save log files.
+        email: An email to use for mail notifications.
+        mail_types: A list of Slurm mail types to specify.
+        extra_sbatch_args: Sequence of args to be passed to sbatch, if any.
+        script_args: Arguments to pass to the script.
+    """
+    result = ["sbatch", "--parsable", "--requeue"]
+    if dependencies:
+        result.extend(
+            [
+                # Don't run this job until the dependencies complete successfully.
+                f"--dependency=afterok:{':'.join(dependencies)}",
+                # If any of the dependencies fail, cancel this job.
+                "--kill-on-invalid-dep=yes",
+            ]
+        )
+    if job_name:
+        result.append(f"--job-name={job_name}")
+    if log_dir:
+        log_dir.mkdir(exist_ok=True, parents=True)
+        result.append(f"--output={str(log_dir.joinpath('R-%x.%j.out'))}")
+
+    result.extend(_build_email_arg(email=email, mail_types=mail_types))
+    result.extend(extra_sbatch_args)
+    result.append(str(script_path))
+    result.extend(script_args)
+
+    return result
+
+
+def build_bash_command(
+    script_path: Path,
+    *,
+    # pylint:disable=unused-argument
+    dependencies: Sequence[SlurmJobID] = (),
+    job_name: Optional[str] = None,
+    log_dir: Optional[Path] = None,
+    email: Optional[Email] = None,
+    mail_types: Sequence[MailType] = (),
+    extra_sbatch_args: Sequence[str] = (),
+    # pylint:enable=unused-argument
+    script_args: Sequence[str],
+) -> Sequence[str]:
+    """
+    Construct a Bash command to run the given sbatch script.
+
+    This returns a sequence of commandline arguments that can be passed directly to
+    subprocess.run(). Note the sbatch commands are ignored.
+
+    Parameters:
+        script_path: The path to the Slurm/sbatch script to run.
+        dependencies:
+            A sequence of Slurm job IDs this job should depend on. These are ignored.
+        job_name: A custom name to use for the job.
+        log_dir: A directory in which to save log files. Ignored.
+        email: An email to use for mail notifications.
+        mail_types: A list of Slurm mail types to specify.
+        extra_sbatch_args: Sequence of args to be passed to sbatch, if any.
+        script_args: Arguments to pass to the script.
+    """
+    result = ["bash", str(script_path)]
+    result.extend(script_args)
+    return result
+
+
+def _build_email_arg(
+    *,
+    email: Optional[str] = None,
+    mail_types: Sequence[str] = (),
+) -> Sequence[str]:
+    result = []
+    if email and mail_types:
+        result = [f"--mail-user={email}", f"--mail-type={','.join(mail_types)}"]
+    return result
+
+
+def echo_command(command: Sequence[str], *, save_to: Optional[Path]) -> Sequence[str]:
+    """
+    Echo the given command returning it unchanged.
+
+    If passed, save_to should be the path to a file. When passed the command will also append the
+    output to the given file.
+    """
+    output = " ".join(shlex.quote(part) for part in command)
+    print(output)
+    if save_to is not None:
+        with save_to.open(mode="a", encoding="utf-8") as save_to_file:
+            print(output, file=save_to_file)
+    return command
+
+
+def run_slurm(
+    command: Sequence[str], *, env: Mapping[str, str], workdir: Path
+) -> Optional[SlurmJobID]:
+    """
+    Run a constructed Slurm command, returning the job ID on success and None otherwise.
+
+    Parameters:
+        command: The pre-constructed Slurm command.
+        env: Environment variables to set, if any.
+    """
+    try:
+        completed_process = run(
+            command, cwd=workdir, capture_output=True, env=env, check=True
+        )
+        result = SlurmJobID(
+            completed_process.stdout.decode(getpreferredencoding()).strip()
+        )
+        slurm_jobs_scheduled.append(result)
+    except CalledProcessError as e:
+        raise ValueError(f"Job run failed for command {command}") from e
+    return result
+
+
+def run_bash(
+    command: Sequence[str], *, env: Mapping[str, str], workdir: Path
+) -> Optional[SlurmJobID]:
+    """
+    Run a constructed Bash command, returning None because Bash doesn't produce Slurm job IDs.
+
+    This is meant for debugging. As a result it always runs the command synchronously. It also pipes
+    the output so you can see what is going on.
+
+    Parameters:
+        command: The pre-constructed Slurm command.
+        env: Environment variables to set, if any.
+    """
+    run(command, cwd=workdir, env=env, check=True)
+    return None
+
+
+def dependency_list(
+    *dependencies: Optional[SlurmJobID],
+) -> Sequence[SlurmJobID]:
+    """
+    Build a dependency list, dropping any null dependencies.
+    """
+    return tuple(dependency for dependency in dependencies if dependency is not None)
+
+
+def add_to_path(bin_dir: Path) -> str:
+    """
+    Construct a new path string by prepending bin_dir to the current PATH.
+    """
+    path_elements = [str(bin_dir)]
+
+    existing_path = getenv("PATH")
+    if existing_path:
+        path_elements.append(existing_path)
+
+    return ":".join(path_elements)
+
+
+def parse_bool_param(params: Parameters, param_name: str) -> bool:
+    """
+    Parse a boolean parameter from the given parameters.
+
+    This is a workaround due to how vistautils handles -p parameters. -p parameters are handy for
+    debugging. However, the typed parameter methods don't interact well with them. Specifically,
+    when you specify a key-value pair with -p, the value is not parsed as YAML, so `-p key true`
+    results in a string value `"true"` for the key `key`. Out of the various parameter types we may
+    want to change during debugging, booleans and paths are probably the most useful, and paths
+    are safe because they have string values under the hood. Hence, this workaround.
+    """
+    try:
+        result = params.boolean(param_name)
+    except ParameterError:
+        result = yaml.safe_load(StringIO(params.string(param_name)))
+    return result
+
+
+def is_empty_dir(path: Path) -> bool:
+    """
+    Return True if the given path is an empty directory, otherwise false.
+    """
+    child = next(path.iterdir(), None)
+    return path.is_dir() and child is None
+
+
+def ignore_from_base_curriculum(_parent: str, children: Sequence[str]) -> Sequence[str]:
+    def is_raw_input_file(path_str: str) -> bool:
+        path = Path(path_str)
+        return (
+            path.name.startswith("semantic")
+            or path.name.startswith("original_colors_color_segmentation_")
+            or path.name.startswith("color_segmentation_")
+            or path.name.startswith("color_refined_semantic_")
+            or path.name.startswith("combined_color_refined_semantic_")
+            or path.name.startswith("stroke_")
+            or path.name.startswith("feature")
+            or path.name.startswith("post_decode")
+        )
+
+    return [child for child in children if is_raw_input_file(child)]
+
+
+def make_run_identifier(run_start: datetime) -> str:
+    return run_start.strftime("%Y-%m-%d_%H:%M:%S%z")
+
+
+def pipeline_entrypoint(params: Parameters) -> None:
+    root = params.existing_directory("adam_root")
+
+    pipeline_params = params.namespace("pipeline")
+    use_sbatch = parse_bool_param(pipeline_params, "use_sbatch")
+    do_object_segmentation = parse_bool_param(pipeline_params, "do_object_segmentation")
+    segmentation_model = pipeline_params.string("segmentation_model")
+    segmentation_api_port = params.integer("segmentation_api_port")
+    segmentation_api_endpoint = f"http://saga03.isi.edu:{segmentation_api_port}"
+    segment_colors = parse_bool_param(pipeline_params, "segment_colors")
+    refine_colors = parse_bool_param(pipeline_params, "refine_colors")
+    strokes_use_refined_colors = parse_bool_param(
+        pipeline_params, "strokes_use_refined_colors"
+    )
+    merge_small_strokes = parse_bool_param(pipeline_params, "merge_small_strokes")
+    extract_strokes = parse_bool_param(pipeline_params, "extract_strokes")
+    train_gnn = parse_bool_param(pipeline_params, "train_gnn")
+    gnn_decode = parse_bool_param(pipeline_params, "gnn_decode")
+    email = Email(pipeline_params.string("email")) if "email" in pipeline_params else None
+    submission_details_path = pipeline_params.creatable_file("submission_details_path")
+    job_logs_path = pipeline_params.creatable_file("job_logs_path")
+    if train_gnn:
+        model_path = pipeline_params.creatable_file("stroke_model_path")
+    elif gnn_decode:
+        model_path = pipeline_params.existing_file("stroke_model_path")
+    else:
+        model_path = None
+    base_train_curriculum_path = pipeline_params.existing_directory(
+        "base_train_curriculum_path"
+    )
+    base_test_curriculum_path = pipeline_params.existing_directory(
+        "base_test_curriculum_path"
+    )
+    train_curriculum_path = pipeline_params.creatable_directory("train_curriculum_path")
+    test_curriculum_path = pipeline_params.creatable_directory("test_curriculum_path")
+    stroke_python_bin_dir = pipeline_params.creatable_directory("stroke_python_bin_dir")
+    adam_params_cache_file = pipeline_params.creatable_file("adam_params_cache_file")
+
+    run_id = make_run_identifier(datetime.now().astimezone())
+    job_logs_path /= run_id
+    job_logs_path.mkdir()
+
+    # We don't also need to swap out run_job_getting_id(). When we run the bash command from this
+    # function, it runs synchronously, such that the job is completed once the function returns.
+    # So even though it returns None, it doesn't matter because we don't have to keep track of
+    # dependencies in that case -- the dependencies are implied by the order the commands are
+    # defined.
+    command_builder = build_sbatch_command if use_sbatch else build_bash_command
+    run_job = run_slurm if use_sbatch else run_bash
+
+    # Truncate the submission details file if it exists, to avoid confusing details with other runs
+    # of the same code
+    if submission_details_path.exists():
+        with submission_details_path.open(mode="w", encoding="utf-8") as _:
+            pass
+    logger.info(
+        "Saving submission details (commands run) to %s.", submission_details_path
+    )
+
+    if use_sbatch:
+        atexit.register(stop_slurm_jobs)
+
+    if train_curriculum_path == base_train_curriculum_path:
+        logger.warning(
+            "Output and base train curriculum paths are the same. Overwriting."
+        )
+    if test_curriculum_path == base_test_curriculum_path:
+        logger.warning("Output and base test curriculum paths are the same. Overwriting.")
+
+    splits = ("train", "test")
+    split_to_name_to_id = {}
+    split_to_base_curriculum_path = {
+        "train": base_train_curriculum_path,
+        "test": base_test_curriculum_path,
+    }
+    split_to_curriculum_path = {
+        "train": train_curriculum_path,
+        "test": test_curriculum_path,
+    }
+
+    # Copy base curriculum if needed
+    for split, path in split_to_curriculum_path.items():
+        if is_empty_dir(path):
+            logger.info(
+                "Copying split %s from base %s to working copy %s.",
+                split,
+                split_to_base_curriculum_path[split],
+                path,
+            )
+            # copytree() doesn't like it if the destination already exists, so make sure it doesn't
+            path.rmdir()
+            copytree(
+                split_to_base_curriculum_path[split],
+                path,
+                ignore=ignore_from_base_curriculum,
+            )
+        elif not path.is_dir():
+            raise RuntimeError(f"Path {path} for split {split} is not a dir.")
+        else:
+            logger.info("Split %s already exists at %s, not copying.", split, path)
+
+    # Start server
+    if do_object_segmentation:
+        # We always run the server using Slurm because the segmentation server requires a GPU
+        server_job_id = run_slurm(
+            echo_command(
+                build_sbatch_command(
+                    root / "segmentation_processing" / "start_server.sh",
+                    script_args=[str(segmentation_api_port)],
+                    job_name="adamSegmentServer",
+                    log_dir=job_logs_path,
+                    email=email,
+                    mail_types=[MailType("FAIL")],
+                ),
+                save_to=submission_details_path,
+            ),
+            env=os.environ,
+            workdir=root / "segmentation_processing",
+        )
+        minutes_delay_before_segmenting = 2
+    # Not really needed, but makes PyCharm happy
+    else:
+        server_job_id = None
+        minutes_delay_before_segmenting = None
+
+    # Run preprocessing
+    for split in splits:
+        curriculum_path = split_to_curriculum_path[split]
+        # PyCharm doesn't understand that we actually reference this key's value later on, such that
+        # the dict's complete setup code can't be converted to a dict literal.
+        # noinspection PyDictCreation
+        name_to_id = {
+            "segmentation": run_job(
+                echo_command(
+                    command_builder(
+                        root / "slurm" / "segment.sh",
+                        extra_sbatch_args=[
+                            f"--dependency=after:{server_job_id}+{minutes_delay_before_segmenting}"
+                        ],
+                        script_args=[
+                            str(curriculum_path),
+                            str(curriculum_path),
+                            segmentation_api_endpoint,
+                            segmentation_model,
+                        ],
+                        job_name=f"adamSegment{split}",
+                        log_dir=job_logs_path,
+                        email=email,
+                        mail_types=[MailType("FAIL")],
+                    ),
+                    save_to=submission_details_path,
+                ),
+                env={"PATH": getenv("PATH", default="")},
+                workdir=root,
+            )
+            if do_object_segmentation
+            else None
+        }
+
+        name_to_id["color_segmentation"] = (
+            run_job(
+                echo_command(
+                    command_builder(
+                        root / "adam_preprocessing" / "color_segment_curriculum.sh",
+                        script_args=[
+                            str(curriculum_path),
+                            str(curriculum_path),
+                        ],
+                        job_name=f"adamColorSeg{split}",
+                        log_dir=job_logs_path,
+                        email=email,
+                        mail_types=[MailType("FAIL")],
+                    ),
+                    save_to=submission_details_path,
+                ),
+                # explicitly add USER to env, because that's what Matlab uses to verify your license
+                # -- not whoami etc. -- and subprocess.run() doesn't set USER by default
+                env={
+                    "PATH": add_to_path(stroke_python_bin_dir),
+                    "USER": getenv("USER", default=""),
+                },
+                workdir=root / "adam_preprocessing",
+            )
+            if segment_colors
+            else None
+        )
+
+        name_to_id["color_refinement"] = (
+            run_job(
+                echo_command(
+                    command_builder(
+                        root / "adam_preprocessing" / "color_refine_curriculum.sh",
+                        script_args=[
+                            str(curriculum_path),
+                            str(curriculum_path),
+                        ],
+                        dependencies=dependency_list(
+                            name_to_id.get("segmentation"),
+                            name_to_id.get("color_segmentation"),
+                        ),
+                        job_name=f"adamColorRef{split}",
+                        log_dir=job_logs_path,
+                        email=email,
+                        mail_types=[MailType("FAIL")],
+                    ),
+                    save_to=submission_details_path,
+                ),
+                # explicitly add USER to env, because that's what Matlab uses to verify your license
+                # -- not whoami etc. -- and subprocess.run() doesn't set USER by default
+                env={
+                    "PATH": add_to_path(stroke_python_bin_dir),
+                    "USER": getenv("USER", default=""),
+                },
+                workdir=root / "adam_preprocessing",
+            )
+            if refine_colors
+            else None
+        )
+
+        name_to_id["stroke_extraction"] = (
+            run_job(
+                echo_command(
+                    command_builder(
+                        root / "adam_preprocessing" / "extract_strokes.sh",
+                        script_args=[
+                            str(curriculum_path),
+                            str(curriculum_path),
+                            "--use-segmentation-type",
+                            "color-refined" if strokes_use_refined_colors else "semantic",
+                            f"--{'' if merge_small_strokes else 'no-'}merge-small-strokes",
+                        ],
+                        dependencies=dependency_list(
+                            name_to_id.get("segmentation"),
+                            name_to_id.get("color_refinement")
+                            if strokes_use_refined_colors
+                            else None,
+                        ),
+                        job_name=f"adamStrokes{split}",
+                        log_dir=job_logs_path,
+                        email=email,
+                        mail_types=[MailType("FAIL")],
+                    ),
+                    save_to=submission_details_path,
+                ),
+                # explicitly add USER to env, because that's what Matlab uses to verify your license
+                # -- not whoami etc. -- and subprocess.run() doesn't set USER by default
+                env={
+                    "PATH": add_to_path(stroke_python_bin_dir),
+                    "USER": getenv("USER", default=""),
+                },
+                workdir=root / "adam_preprocessing",
+            )
+            if extract_strokes
+            else None
+        )
+        split_to_name_to_id[split] = name_to_id
+
+    # Stop server after the segmentation jobs are done
+    if do_object_segmentation:
+        train_segmentation_job = split_to_name_to_id["train"]["segmentation"]
+        test_segmentation_job = split_to_name_to_id["test"]["segmentation"]
+        run_slurm(
+            echo_command(
+                # Construct the command directly because it's a weird one-off and doesn't use a script
+                [
+                    "sbatch",
+                    "--account=borrowed",
+                    "--partition=scavenge",
+                    "--ntasks=1",
+                    "--cpus-per-task=1",
+                    "--mem-per-cpu=1g",
+                    "--requeue",
+                    f"--dependency=afterany:{train_segmentation_job}:{test_segmentation_job}",
+                    f"--wrap=scancel {server_job_id}",
+                ],
+                save_to=submission_details_path,
+            ),
+            env=os.environ,
+            workdir=root,
+        )
+
+    # Train GNN
+    gnn_train_job = (
+        run_job(
+            echo_command(
+                command_builder(
+                    root / "adam_preprocessing" / "train.sh",
+                    script_args=[
+                        str(split_to_curriculum_path["train"]),
+                        str(split_to_curriculum_path["test"]),
+                        str(model_path),
+                    ],
+                    dependencies=dependency_list(
+                        split_to_name_to_id["train"].get("stroke_extraction")
+                    ),
+                    job_name="adamGNNTrain",
+                    log_dir=job_logs_path,
+                    email=email,
+                    mail_types=[MailType("FAIL")],
+                ),
+                save_to=submission_details_path,
+            ),
+            env={"PATH": add_to_path(stroke_python_bin_dir)},
+            workdir=root / "adam_preprocessing",
+        )
+        if train_gnn
+        else None
+    )
+
+    # Get GNN decodes
+    for split in splits:
+        name_to_id = split_to_name_to_id[split]
+        split_curriculum_dir = split_to_curriculum_path[split]
+        name_to_id["decode"] = (
+            run_job(
+                echo_command(
+                    command_builder(
+                        root / "adam_preprocessing" / "predict.sh",
+                        script_args=[
+                            str(model_path),
+                            str(split_curriculum_dir),
+                            str(split_curriculum_dir),
+                        ],
+                        dependencies=dependency_list(
+                            name_to_id.get("stroke_extraction"), gnn_train_job
+                        ),
+                        job_name=f"adamGNNDecode{split}",
+                        log_dir=job_logs_path,
+                        email=email,
+                        mail_types=[MailType("FAIL")],
+                    ),
+                    save_to=submission_details_path,
+                ),
+                env={"PATH": add_to_path(stroke_python_bin_dir)},
+                workdir=root / "adam_preprocessing",
+            )
+            if gnn_decode
+            else None
+        )
+
+    # Run ADAM train and test
+    # Dump the final params file to the given output spot.
+    # Note this also includes the pipeline parameters. That's fine -- ADAM shouldn't process them.
+    with adam_params_cache_file.open("w", encoding="utf-8") as params_out:
+        yaml.dump(params.as_nested_dicts(), params_out)
+
+    run_job(
+        echo_command(
+            command_builder(
+                root / "slurm" / "adam.sh",
+                script_args=[str(adam_params_cache_file)],
+                dependencies=dependency_list(
+                    *[split_to_name_to_id[split].get("decode") for split in splits]
+                ),
+                job_name="adamADAM",
+                log_dir=job_logs_path,
+                email=email,
+                mail_types=[MailType("SUCCESS"), MailType("FAIL")],
+            ),
+            save_to=submission_details_path,
+        ),
+        env=os.environ,
+        workdir=root,
+    )
+
+    if use_sbatch:
+        atexit.unregister(stop_slurm_jobs)
+
+
+if __name__ == "__main__":
+    parameters_only_entry_point(pipeline_entrypoint)

--- a/adam/experiment/run_pipeline.py
+++ b/adam/experiment/run_pipeline.py
@@ -545,7 +545,7 @@ def pipeline_entrypoint(params: Parameters) -> None:
                     "--requeue",
                     f"--dependency=afterany:{train_segmentation_job}:{test_segmentation_job}",
                     "--job-name=adamCancelServer",
-                    f"--output=R-%x.%j.out",
+                    f"--output={str(job_logs_path.joinpath('R-%x.%j.out'))}",
                     f"--wrap=scancel {server_job_id}",
                 ],
                 save_to=submission_details_path,

--- a/adam/experiment/run_pipeline.py
+++ b/adam/experiment/run_pipeline.py
@@ -1,9 +1,6 @@
 """
 A script intended to run the entire Phase 3 pipeline (as of milestone 6).
 
-Note that this script does not take care of starting the object segmentation server. You have to do
-that separately.
-
 Note also that this writes to then reads from a params file for ADAM. If you run this again with the
 same params file name while a job is running, you will overwrite the old parameters! So be careful.
 """

--- a/adam/experiment/run_pipeline.py
+++ b/adam/experiment/run_pipeline.py
@@ -544,6 +544,8 @@ def pipeline_entrypoint(params: Parameters) -> None:
                     "--mem-per-cpu=1g",
                     "--requeue",
                     f"--dependency=afterany:{train_segmentation_job}:{test_segmentation_job}",
+                    "--job-name=adamCancelServer",
+                    f"--output=R-%x.%j.out",
                     f"--wrap=scancel {server_job_id}",
                 ],
                 save_to=submission_details_path,

--- a/adam/experiment/run_pipeline.py
+++ b/adam/experiment/run_pipeline.py
@@ -1,5 +1,5 @@
 """
-A script intended to run the entire M3 pipeline.
+A script intended to run the entire Phase 3 pipeline (as of milestone 6).
 
 Note that this script does not take care of starting the object segmentation server. You have to do
 that separately.

--- a/adam_preprocessing/color_refinement.py
+++ b/adam_preprocessing/color_refinement.py
@@ -1,5 +1,8 @@
 """
-Perform color segmentation refinement on an RGB image and pre-existing segmentation mask.
+Combine an instance segmentation mask and a color segmentation mask to produce a refined mask.
+
+This can produce either a combined mask image or one image per object (distinct mask) in the
+instance segmentation.
 """
 from argparse import ArgumentParser
 import logging
@@ -8,8 +11,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from color_segmentation import (
-    do_color_segmentation,
+from mask_image import (
     colors_to_index_np,
     with_random_colors,
 )
@@ -77,9 +79,9 @@ def main():
     )
 
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument("rgb_img_path", type=Path, help="The RGB image to be segmented.")
+    parser.add_argument("color_seg_img_path", type=Path, help="The color segmentation image.")
     parser.add_argument(
-        "seg_img_path", type=Path, help="The segmentation image to be refined."
+        "inst_seg_img_path", type=Path, help="The instance segmentation image."
     )
     parser.add_argument(
         "--save_refined_segs_to",
@@ -107,8 +109,8 @@ def main():
     )
     args = parser.parse_args()
 
-    segmentation = cv2.imread(str(args.seg_img_path))
-    color_segmentation = do_color_segmentation(args.rgb_img_path)
+    segmentation = cv2.imread(str(args.inst_seg_img_path))
+    color_segmentation = cv2.imread(str(args.color_seg_img_path))
 
     # Randomize color segmentation colors if needed.
     if args.use_random_colors:

--- a/adam_preprocessing/color_segment_curriculum.py
+++ b/adam_preprocessing/color_segment_curriculum.py
@@ -1,0 +1,118 @@
+"""
+Perform color segmentation and refinement on an entire input curriculum.
+"""
+from argparse import ArgumentParser
+import json
+import logging
+import os.path
+from pathlib import Path
+import re
+
+from tqdm import tqdm
+import yaml
+
+from color_segmentation import segment_rgb_file
+
+logger = logging.getLogger(__name__)
+file_dir = os.path.dirname(__file__)
+
+
+IMAGE_NUMBER_REGEX = re.compile(r"[a-zA-Z_]+_(\d+).png")
+
+
+def parse_image_number(filename: str) -> int:
+    """
+    Parse image number from a filename.
+
+    The filename (sans extension) should consist of ASCII letters and underscores and contain just
+    one integer. The integer must immediately precede the .png.
+    """
+    return int(re.sub(IMAGE_NUMBER_REGEX, r"\1", filename))
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "curriculum_path",
+        type=Path,
+        help="The curriculum path to process.",
+    )
+    parser.add_argument(
+        "output_dir",
+        type=Path,
+        help="The output curriculum dir.",
+    )
+    parser.add_argument(
+        "--dir-num",
+        default=None,
+        help="A specific situation directory number to process. If provided only this directory is processed."
+    )
+    parser.add_argument(
+        "--color-seed",
+        type=int,
+        default=42,
+        help="The seed to use when randomizing the color segmentation region colors."
+    )
+    parser.add_argument(
+        "--multifile-output",
+        action="store_true",
+        help="When enabled, save K files per segmentation (K being the number of objects)."
+    )
+    parser.add_argument(
+        "--no-multifile-output",
+        action="store_false",
+        dest="multifile_output",
+        help="When passed, save 1 output file per segmentation input."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    # copied and edited from phase3_load_from_disk() -- see adam.curriculum.curriculum_from_files
+    if args.dir_num:
+        logger.info(f"Processing directory number {args.dir_num}")
+    else:
+        with open(
+            args.curriculum_path / "info.yaml", encoding="utf=8"
+        ) as curriculum_info_yaml:
+            curriculum_params = yaml.safe_load(curriculum_info_yaml)
+        logger.info("Input curriculum has %d dirs/situations.", curriculum_params["num_dirs"])
+
+    for situation_num in tqdm(
+        range(curriculum_params["num_dirs"]) if args.dir_num is None else [args.dir_num],
+        desc="Situations processed",
+        total=curriculum_params["num_dirs"] if args.dir_num is None else 1,
+    ):
+        situation_dir = args.curriculum_path / f"situation_{situation_num}"
+        output_situation_dir = args.output_dir / f"situation_{situation_num}"
+        output_situation_dir.mkdir(exist_ok=True, parents=True)
+
+        # Segment RGB files assuming one segmentation file per RGB image
+        failed_image_numbers = []
+        for rgb_image in sorted(situation_dir.glob("rgb_*.png")):
+            number = parse_image_number(rgb_image.name)
+            try:
+                segment_rgb_file(
+                    rgb=rgb_image,
+                    save_with_proper_colors_to=output_situation_dir / f"original_colors_color_segmentation_{number}.png",
+                    save_with_random_colors_to=output_situation_dir / f"color_segmentation_{number}.png",
+                    color_seed=args.color_seed,
+                )
+            # jac: For some images we may not be able to refine the segmentation due to errors in
+            # the Matlab code. For now, ignore such errors and move on.
+            except ValueError:
+                logger.debug(
+                    "Couldn't segment image %s in situation %d, continuing...",
+                    rgb_image.name,
+                    situation_num,
+                )
+                failed_image_numbers.append(number)
+                continue
+
+        output_situation_dir.joinpath("color_segmentation_metadata.json").write_text(
+            json.dumps({"failed_image_numbers": failed_image_numbers}) + "\n", encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/adam_preprocessing/color_segment_curriculum.sh
+++ b/adam_preprocessing/color_segment_curriculum.sh
@@ -4,7 +4,7 @@
 #SBATCH --partition=adam
 #SBATCH --time=23:00:00 # Number of hours required per node, max 24 on SAGA
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
+#SBATCH --cpus-per-task=2
 #SBATCH --mem=32g
 #SBATCH --gpus-per-task=1
 #SBATCH --nodes=1

--- a/adam_preprocessing/color_segment_curriculum.sh
+++ b/adam_preprocessing/color_segment_curriculum.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=clrSegCurriculum
+#SBATCH --account=adam
+#SBATCH --partition=adam
+#SBATCH --time=23:00:00 # Number of hours required per node, max 24 on SAGA
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32g
+#SBATCH --gpus-per-task=1
+#SBATCH --nodes=1
+#SBATCH --mail-type=FAIL,END
+#SBATCH --output=R-%x.%j.out
+# Need to run on ADAM partition (saga03 or adam-dev) because this uses Matlab.
+set -u
+
+if [[ "$#" -lt 2 ]] || [[ "$1" = "--help" ]] ; then
+  printf '%s\n' "usage: $0 input_curriculum_dir output_curriculum_dir"
+  python color_refine_curriculum.py --help
+  exit 1
+else
+  input_curriculum_dir=$1
+  output_curriculum_dir=$2
+  shift 2
+fi
+
+# Because we force there to be only 2 args and then shift by 2, "$@" should expand to nothing.
+# It's included as future-proofing in case we add/allow more args.
+#
+# Note that because CentOS 7 uses an old version of glibc, we have to preload a shim in order to
+# import the Matlab extension used in the stroke extraction code. This shim provides a definition
+# of __cxa_thread_atexit_impl which is only defined in glibc 2.18+. Without preloading, the
+# extension causes a crash due to an undefined symbol error.
+shim_path=/nas/gaia/adam/matlab/bin/glnxa64/glibc-2.17_shim.so
+LD_PRELOAD="$shim_path" python color_segment_curriculum.py "$input_curriculum_dir" "$output_curriculum_dir" "$@"

--- a/adam_preprocessing/color_segmentation.py
+++ b/adam_preprocessing/color_segmentation.py
@@ -12,11 +12,13 @@ from argparse import ArgumentParser
 import logging
 import os.path
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union
+from typing import Tuple, Union
 
 import cv2
 import matlab.engine
 import numpy as np
+
+from mask_image import colors_to_index_np, with_random_colors
 
 logger = logging.getLogger(__name__)
 file_dir = os.path.dirname(__file__)
@@ -45,93 +47,6 @@ def do_color_segmentation(imgpath: Union[Path, str]) -> np.ndarray:
         raise ValueError(f"Could not properly color-segment image {imgpath}") from e
     eng.close()
     return (np.array(out) * 255).astype(np.uint8)
-
-
-def colors_to_index_np(
-    color_img: np.ndarray,
-) -> Tuple[np.ndarray, Dict[int, np.ndarray], np.ndarray]:
-    """
-    Given an RGB image, convert it to an indexed-color image.
-
-    This implementation uses Numpy. It should be much faster but might not work in all cases.
-
-    Parameters:
-        color_img: A NumPy array of colors having shape (H, W, 3).
-
-    Returns:
-        At [0], a NumPy integer array of shape (H, W) where each value is an index.
-            [1]: the index to color mapping.
-            [2]: the array of unique colors of shape (N, 3) where N is the number of unique colors.
-    """
-    unique, inv = np.unique(color_img.reshape(-1, 3), axis=0, return_inverse=True)
-    return inv.reshape(color_img.shape[0:2]), {k: unique[k] for k in inv}, unique
-
-
-def colors_to_index_hack(
-    color_img: np.ndarray,
-) -> Tuple[np.ndarray, Dict[int, np.ndarray], np.ndarray]:
-    """
-    Given an RGB image, convert it to an indexed-color image.
-
-    This is a quick implementation, so it may be slow. I did a quick search for a similar function
-    in cv2 and didn't find one.
-
-    Parameters:
-        color_img: A NumPy array of colors having shape (H, W, 3).
-
-    Returns:
-        At [0], a NumPy integer array of shape (H, W) where each value is an index.
-            [1]: the index to color mapping.
-            [2]: the array of unique colors of shape (N, 3) where N is the number of unique colors.
-    """
-    # Index colors
-    color_to_index = {}
-    k = 0
-    for i in range(color_img.shape[0]):
-        for j in range(color_img.shape[1]):
-            color = color_img[i, j]
-            if color not in color_to_index:
-                color_to_index[color_img[i, j]] = k
-                k += 1
-
-    # Convert to indexed image
-    indexed_image = np.zeros(color_img.shape[0:2], dtype=np.int)
-    for i in range(color_img.shape[0]):
-        for j in range(color_img.shape[1]):
-            indexed_image[i, j] = color_to_index[color_img[i, j]]
-
-    unique = np.stack([key for key in color_to_index.keys()], axis=0)
-    return indexed_image, {v: k for k, v in color_to_index.items()}, unique
-
-
-def with_random_colors(
-    indexed_img: np.ndarray,
-    *,
-    n_colors: Optional[int] = None,
-    color_seed: Optional[int] = None,
-) -> np.ndarray:
-    """
-    Given an indexed-color image, apply random colors to it.
-
-    This is a quick implementation, so it may be slow. I did a quick search for a similar function
-    in cv2 and didn't find one.
-
-    Parameters:
-        indexed_img: A NumPy array of shape (H, W) representing an indexed-color image.
-        n_colors:
-            The number of colors to use. Can be calculated from the indexed image; passing this just
-            saves time.
-        color_seed:
-            The seed used to generate random colors.
-
-    Returns:
-        A color image with random colors, being a NumPy integer array of shape (H, W, 3).
-    """
-    if not n_colors:
-        n_colors = np.max(indexed_img) + 1
-    rng = np.random.default_rng(color_seed)
-    random_colors = rng.uniform(0, 256, size=(n_colors, 3)).astype(np.uint8)
-    return np.take(random_colors, indices=indexed_img, axis=0)
 
 
 def segment_rgb_file(

--- a/adam_preprocessing/extract_strokes.sh
+++ b/adam_preprocessing/extract_strokes.sh
@@ -4,7 +4,7 @@
 #SBATCH --partition=adam
 #SBATCH --time=4:00:00 # Number of hours required per node, max 24 on SAGA
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=8
+#SBATCH --cpus-per-task=4
 #SBATCH --mem=32g
 #SBATCH --nodes=1
 #SBATCH --mail-type=FAIL,END

--- a/adam_preprocessing/mask_image.py
+++ b/adam_preprocessing/mask_image.py
@@ -1,0 +1,95 @@
+"""
+Code for working with mask images.
+
+Mask images represent objects or regions using
+"""
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+def colors_to_index_np(
+    color_img: np.ndarray,
+) -> Tuple[np.ndarray, Dict[int, np.ndarray], np.ndarray]:
+    """
+    Given an RGB image, convert it to an indexed-color image.
+
+    This implementation uses Numpy. It should be much faster but might not work in all cases.
+
+    Parameters:
+        color_img: A NumPy array of colors having shape (H, W, 3).
+
+    Returns:
+        At [0], a NumPy integer array of shape (H, W) where each value is an index.
+            [1]: the index to color mapping.
+            [2]: the array of unique colors of shape (N, 3) where N is the number of unique colors.
+    """
+    unique, inv = np.unique(color_img.reshape(-1, 3), axis=0, return_inverse=True)
+    return inv.reshape(color_img.shape[0:2]), {k: unique[k] for k in inv}, unique
+
+
+def colors_to_index_hack(
+    color_img: np.ndarray,
+) -> Tuple[np.ndarray, Dict[int, np.ndarray], np.ndarray]:
+    """
+    Given an RGB image, convert it to an indexed-color image.
+
+    This is a quick implementation, so it may be slow. I did a quick search for a similar function
+    in cv2 and didn't find one.
+
+    Parameters:
+        color_img: A NumPy array of colors having shape (H, W, 3).
+
+    Returns:
+        At [0], a NumPy integer array of shape (H, W) where each value is an index.
+            [1]: the index to color mapping.
+            [2]: the array of unique colors of shape (N, 3) where N is the number of unique colors.
+    """
+    # Index colors
+    color_to_index = {}
+    k = 0
+    for i in range(color_img.shape[0]):
+        for j in range(color_img.shape[1]):
+            color = color_img[i, j]
+            if color not in color_to_index:
+                color_to_index[color_img[i, j]] = k
+                k += 1
+
+    # Convert to indexed image
+    indexed_image = np.zeros(color_img.shape[0:2], dtype=np.int)
+    for i in range(color_img.shape[0]):
+        for j in range(color_img.shape[1]):
+            indexed_image[i, j] = color_to_index[color_img[i, j]]
+
+    unique = np.stack([key for key in color_to_index.keys()], axis=0)
+    return indexed_image, {v: k for k, v in color_to_index.items()}, unique
+
+
+def with_random_colors(
+    indexed_img: np.ndarray,
+    *,
+    n_colors: Optional[int] = None,
+    color_seed: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Given an indexed-color image, apply random colors to it.
+
+    This is a quick implementation, so it may be slow. I did a quick search for a similar function
+    in cv2 and didn't find one.
+
+    Parameters:
+        indexed_img: A NumPy array of shape (H, W) representing an indexed-color image.
+        n_colors:
+            The number of colors to use. Can be calculated from the indexed image; passing this just
+            saves time.
+        color_seed:
+            The seed used to generate random colors.
+
+    Returns:
+        A color image with random colors, being a NumPy integer array of shape (H, W, 3).
+    """
+    if not n_colors:
+        n_colors = np.max(indexed_img) + 1
+    rng = np.random.default_rng(color_seed)
+    random_colors = rng.uniform(0, 256, size=(n_colors, 3)).astype(np.uint8)
+    return np.take(random_colors, indices=indexed_img, axis=0)

--- a/adam_preprocessing/shape_stroke_extraction.py
+++ b/adam_preprocessing/shape_stroke_extraction.py
@@ -678,7 +678,7 @@ class Stroke_Extraction:
         coef_inv = get_bsplines_matrix(10)
         for i in range(len(self.strokes)):
             reduced_strokes.append(reduced_stroke(self.strokes[i], coef_inv))
-        self.reduced_strokes = reduced_strokes = np.array(reduced_strokes)
+        self.reduced_strokes = reduced_strokes = np.array(reduced_strokes, dtype=np.float64)
 
     def plot_strokes(self):
         """

--- a/parameters/experiments/p3/m6_pipeline_debug.params
+++ b/parameters/experiments/p3/m6_pipeline_debug.params
@@ -1,0 +1,82 @@
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: false
+    do_object_segmentation: true
+    segmentation_model: "stego"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m5_objects_v0_with_mugs"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m5_objects_v0_with_mugs_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_pipeline_debug"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_pipeline_debug_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_pipeline_debug"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/slurm/adam.sh
+++ b/slurm/adam.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #SBATCH --job-name=ADAM
 #SBATCH --account=borrowed
-#SBATCH --partition=scavenge
-#SBATCH --qos=scavenge
+#SBATCH --partition=ephemeral
+#SBATCH --qos=ephemeral
 #SBATCH --time=1:00:00 # Number of hours required per node, max 24 on SAGA
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4

--- a/slurm/adam.sh
+++ b/slurm/adam.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ADAM
+#SBATCH --account=borrowed
+#SBATCH --partition=scavenge
+#SBATCH --qos=scavenge
+#SBATCH --time=1:00:00 # Number of hours required per node, max 24 on SAGA
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32g
+#SBATCH --nodes=1
+#SBATCH --mail-type=FAIL,SUCCESS
+#SBATCH --output=R-%x.%j.out
+set -u
+
+if [[ "$#" -ne 1 ]] || [[ "$1" = "--help" ]] ; then
+  printf '%s\n' "usage: $0 params_file"
+  exit 1
+else
+  params_file=$1
+  shift 1
+fi
+
+# future-proofing "$@"
+PYTHONPATH=. python adam/experiment/log_experiment.py "$params_file" "$@"

--- a/slurm/segment.sh
+++ b/slurm/segment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=adamSegment
+#SBATCH --account=borrowed
+#SBATCH --partition=scavenge
+#SBATCH --qos=scavenge
+#SBATCH --time=1:00:00 # Number of hours required per node, max 24 on SAGA
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32g
+#SBATCH --nodes=1
+#SBATCH --mail-type=FAIL,SUCCESS
+#SBATCH --output=R-%x.%j.out
+set -u
+
+if [[ "$#" -ne 4 ]] || [[ "$1" = "--help" ]] ; then
+  printf '%s\n' "usage: $0 input_curriculum output_curriculum api model"
+  exit 1
+else
+  input_curriculum=$1
+  output_curriculum=$2
+  api=$3
+  model=$4
+  shift 4
+fi
+
+# future-proofing "$@"
+PYTHONPATH=. python adam/curriculum/generate_segmentation_results.py \
+  --base-curriculum "$input_curriculum" \
+  --save-to "$output_curriculum" \
+  --api "$api" \
+  --model "$model"

--- a/slurm/segment.sh
+++ b/slurm/segment.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #SBATCH --job-name=adamSegment
 #SBATCH --account=borrowed
-#SBATCH --partition=scavenge
-#SBATCH --qos=scavenge
+#SBATCH --partition=ephemeral
+#SBATCH --qos=ephemeral
 #SBATCH --time=1:00:00 # Number of hours required per node, max 24 on SAGA
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4


### PR DESCRIPTION
Implements a script to queue all preprocessing steps from one script. The preprocessing steps are queued as separate Slurm jobs with dependencies on each other, set up to cancel immediately if one of their dependencies is canceled/fails. This script can also supports running each step iteratively and interactively by running the Slurm scripts in Bash.

I haven't yet tested this with color segmentation or instance segmentation. Once I have both working I may add segmentation server startup to this.