### PR TITLE
Fix GNN decode when some situations are missing stroke output

### DIFF
--- a/adam_preprocessing/shape_stroke_graph_inference.py
+++ b/adam_preprocessing/shape_stroke_graph_inference.py
@@ -168,8 +168,6 @@ def main():
                 args.curriculum_path / "info.yaml", encoding="utf=8"
             ) as curriculum_info_yaml:
                 curriculum_params = yaml.safe_load(curriculum_info_yaml)
-            if outputs is not None and not args.multi_object:
-                assert outputs.size(0) == curriculum_params["num_dirs"]
 
         n_saved = 0
         objs_seen = 0
@@ -190,29 +188,13 @@ def main():
                     predictions_by_object = []
                     num_objs = len(features['objects'])
 
-                    # If in multi-object mode, predict separately for each
-                    # object (object_idx points to this object among all
-                    # objects in the curriculum):
-                    if args.multi_object:
-                        predictions_by_object.extend(
-                            [STRING_OBJECT_LABELS[
-                                predicted_label_ints[object_idx if args.dir_num
-                                is None else 0][i]] for i in range(args.top_k)
-                            ] for object_idx in
-                            range(objs_seen, objs_seen + num_objs)
-                        )
+                    predictions_by_object.extend(
+                        [
+                            STRING_OBJECT_LABELS[predicted_label_ints[object_idx][i]]
+                            for i in range(args.top_k)
+                        ] for object_idx in situation_number_to_object_indices[situation_num]
+                    )
 
-                    # If in single-object mode, make a single prediction per
-                    # situation, then pretend that 1 prediction is <num_objs>
-                    # predictions for a later function that expects there to
-                    # be <num_objs> predictions for each feature file
-                    else:
-                        object_predictions = [
-                            STRING_OBJECT_LABELS[
-                                predicted_label_ints[situation_num if args.dir_num is None else 0][i]] for i in range(args.top_k)
-                        ]
-                        for i in range(num_objs):
-                            predictions_by_object.append(object_predictions)
                     objs_seen += num_objs
 
                 updated_features = update_features_yaml(

--- a/adam_preprocessing/shape_stroke_graph_inference.py
+++ b/adam_preprocessing/shape_stroke_graph_inference.py
@@ -185,17 +185,13 @@ def main():
                     predictions_by_object = [["unknown"]]
                 else:
                     _, predicted_label_ints = outputs.topk(args.top_k)
-                    predictions_by_object = []
-                    num_objs = len(features['objects'])
-
-                    predictions_by_object.extend(
+                    predictions_by_object = [
                         [
                             STRING_OBJECT_LABELS[predicted_label_ints[object_idx][i]]
                             for i in range(args.top_k)
                         ] for object_idx in situation_number_to_object_indices[situation_num]
-                    )
-
-                    objs_seen += num_objs
+                    ]
+                    objs_seen += len(features['objects'])
 
                 updated_features = update_features_yaml(
                     features,

--- a/adam_preprocessing/shape_stroke_graph_inference.py
+++ b/adam_preprocessing/shape_stroke_graph_inference.py
@@ -88,7 +88,13 @@ def main():
 
     "Processing data from image to stroke graph"
     logging.info("Loading test data...")
-    test_coords, test_adj, test_label = get_stroke_data(args.curriculum_path, "test", dir_num=args.dir_num, int_curriculum_labels=args.compute_accuracy, multi_object=args.multi_object)
+    situation_number_to_object_indices, test_coords, test_adj, test_label = get_stroke_data(
+        args.curriculum_path,
+        "test",
+        dir_num=args.dir_num,
+        int_curriculum_labels=args.compute_accuracy,
+        multi_object=args.multi_object,
+    )
     logging.info("Done loading data.")
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")

--- a/adam_preprocessing/shape_stroke_graph_learner.py
+++ b/adam_preprocessing/shape_stroke_graph_learner.py
@@ -54,11 +54,13 @@ def main():
     logging.basicConfig(level=logging.INFO)
     "Processing data from image to stroke graph"
     logging.info("Loading training data...")
-    train_coords, train_adj, train_label = get_stroke_data(
+    _, train_coords, train_adj, train_label = get_stroke_data(
         args.train_curriculum_path, "train", multi_object=args.multi_object
     )
     logging.info("Loading test data...")
-    test_coords, test_adj, test_label = get_stroke_data(args.eval_curriculum_path, "test", multi_object=args.multi_object)
+    _, test_coords, test_adj, test_label = get_stroke_data(
+        args.eval_curriculum_path, "test", multi_object=args.multi_object
+    )
     logging.info("Done loading data.")
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
     "Converting stroke graph data for graph node/edge. "

--- a/adam_preprocessing/utils.py
+++ b/adam_preprocessing/utils.py
@@ -36,7 +36,12 @@ STRING_OBJECT_LABELS = [
 
 
 def get_stroke_data(
-    curriculum_path: Path, train_or_test: str, *, dir_num: Optional[int] = None, int_curriculum_labels: bool = True, multi_object: bool = False
+    curriculum_path: Path,
+    train_or_test: str,
+    *,
+    dir_num: Optional[int] = None,
+    int_curriculum_labels: bool = True,
+    multi_object: bool = False,
 ) -> Tuple[Sequence[np.ndarray], Sequence[np.ndarray], Sequence[int]]:
     """Load data on strokes from each scenario feature file in each scenario
        dir in curriculum.

--- a/adam_preprocessing/utils.py
+++ b/adam_preprocessing/utils.py
@@ -2,7 +2,7 @@
 # original code by Sheng Cheng
 import logging
 from pathlib import Path
-from typing import Sequence, Tuple, Optional
+from typing import Mapping, Sequence, Tuple, Optional
 import yaml
 
 import torch.nn as nn
@@ -42,7 +42,7 @@ def get_stroke_data(
     dir_num: Optional[int] = None,
     int_curriculum_labels: bool = True,
     multi_object: bool = False,
-) -> Tuple[Sequence[np.ndarray], Sequence[np.ndarray], Sequence[int]]:
+) -> Tuple[Mapping[int, Sequence[int]], Sequence[np.ndarray], Sequence[np.ndarray], Sequence[int]]:
     """Load data on strokes from each scenario feature file in each scenario
        dir in curriculum.
 
@@ -58,6 +58,10 @@ def get_stroke_data(
         multi_object: whether to treat objects as separate or to fuse them
 
     Returns:
+        situation_number_to_object_index:
+            Maps each situation by number to a list of object indices. The list gives the objects
+            belonging to that situation. These object indices should be interpreted as indices into
+            the following lists.
         curriculum_coords: list of all stroke coordinate arrays in curriculum
                            (1 per object if multi_object, otherwise 1 per
                            situation)
@@ -72,9 +76,11 @@ def get_stroke_data(
         with open(curriculum_path / "info.yaml", encoding="utf=8") as curriculum_info_yaml:
             curriculum_params = yaml.safe_load(curriculum_info_yaml)
 
+    situation_number_to_object_indices = {}
     curriculum_coords = []
     curriculum_adjs = []
     curriculum_labels = []
+    n_objects_from_all_situations = 0
     for situation_num in range(curriculum_params["num_dirs"]) if dir_num is None else [dir_num]:
         situation_dir = curriculum_path / f"situation_{situation_num}"
         language_tuple: Tuple[str, ...] = tuple()
@@ -89,6 +95,8 @@ def get_stroke_data(
                 f"Training situations must provide a description, but situation {situation_num} "
                 f"in {curriculum_path} does not."
             )
+
+        situation_number_to_object_indices[situation_num] = []
 
         feature_yamls = sorted(situation_dir.glob("feature*"))
         if len(feature_yamls) == 1:
@@ -176,7 +184,13 @@ def get_stroke_data(
                 f"one feature file."
             )
 
-    return curriculum_coords, curriculum_adjs, curriculum_labels
+        n_objects = len(features["objects"]) if multi_object else 1
+        situation_number_to_object_indices[situation_num].extend(
+            range(n_objects_from_all_situations, n_objects_from_all_situations + n_objects)
+        )
+        n_objects_from_all_situations += n_objects
+
+    return situation_number_to_object_indices, curriculum_coords, curriculum_adjs, curriculum_labels
 
 
 def label_from_object_language_tuple(


### PR DESCRIPTION
Closes #1187. I've tested this briefly and it seems to fix the crash. I tested on the "M5 objects v0 with mugs" curriculum both single-object and multi-object. I also tested with the live demo, using both "good" examples and some examples where we know we won't get any strokes.