### PR TITLE
Add flag to drop situations with no strokes

### DIFF
--- a/scripts/reorganize_curriculum.py
+++ b/scripts/reorganize_curriculum.py
@@ -86,8 +86,8 @@ def main():
         "--keep-strokeless-situations",
         dest="drop_strokeless_situations",
         action="store_false",
-        help="If passed, include in the output any situations lacking stroke features. This is the "
-        "default behavior.",
+        help="If passed, do not drop situations just because they lack stroke features. This is "
+        "the default behavior.",
     )
     parser.add_argument("--output-dir", type=Path, help="The curriculum output directory", required=True)
     args = parser.parse_args()

--- a/scripts/reorganize_curriculum.py
+++ b/scripts/reorganize_curriculum.py
@@ -29,7 +29,6 @@ OBJECTS_LIST = (
     "triangleblock",
     "window",
 )
-N_EXAMPLES_PER_OBJECT = 10
 N_CAMERAS = 3
 
 
@@ -60,6 +59,13 @@ def main():
     parser.add_argument("--input-feature-dir", type=Path, help="An input directory of the features", required=True)
     parser.add_argument("--input-cur-dir", type=Path, help="An input directory of the curriculum", required=True)
     parser.add_argument("--input-split", type=str, help="The input curriculum split to process", required=True)
+    parser.add_argument(
+        "--examples-per-object",
+        type=int,
+        help="The number of examples per object. This is 10 for M5 objects train, 5 for M5 objects "
+        "test.",
+        required=True,
+    )
     parser.add_argument(
         "--input-slice",
         type=str,
@@ -93,7 +99,7 @@ def main():
     situation_num = 0
     objects_covered = set()
     for object_debug_name, range_examples, n_cameras in zip(
-        OBJECTS_LIST, itt.repeat(N_EXAMPLES_PER_OBJECT), itt.repeat(N_CAMERAS)
+        OBJECTS_LIST, itt.repeat(args.examples_per_object), itt.repeat(N_CAMERAS)
     ):
         for cam in range(n_cameras):
             input_curriculum_dir: Path = args.input_cur_dir / f"{args.input_split}_{args.input_slice}{object_debug_name}" / f"cam{cam}"


### PR DESCRIPTION
This should address the problem where we don't include all of ASU's output situations in our curriculum. Including everything makes proper analysis simpler since we don't have to explicitly factor in the `x` situations that were lacking strokes. Also because of differences between ASU's and our stroke extraction output we may be able to use those `x` situations after all -- especially given we're using a different, out-of-AirSim way of segmenting.