### PR TITLE
Organize new curriculum

### DIFF
--- a/adam/curriculum/filter_curriculum.py
+++ b/adam/curriculum/filter_curriculum.py
@@ -1,0 +1,70 @@
+"""A script to filter a given curriculum along a given condition.
+
+Default filtering is for Object Training Curriculums where this filter ensures
+only a single object is present in the YAML data."""
+import argparse
+import logging
+from pathlib import Path
+from typing import Mapping, Any, Sequence, MutableMapping
+
+import yaml
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def clean_object_yaml(object_yaml: MutableMapping[str, Any]) -> Mapping[str, Any]:
+    """Cleans an object yaml of relationship fields."""
+    object_yaml["distance"] = {}
+    object_yaml["relative_distance"] = {}
+    object_yaml["relative_size"] = {}
+
+    return object_yaml
+
+
+def filter_by_largest_box_area(
+    objects_: Sequence[MutableMapping[str, Any]]
+) -> Mapping[str, Any]:
+    """Filter a set of objects by the largest box area constraint."""
+
+    return clean_object_yaml(max(objects_, key=lambda x: x["size"]["box_area"]))
+
+
+def main() -> None:
+    """Script to filter curriculum to single objects for training."""
+    parser = argparse.ArgumentParser(
+        description="Utility script to reorganize Action curricula"
+    )
+    parser.add_argument(
+        "curriculum_path", type=Path, help="Curriculum to apply filtering to."
+    )
+    args = parser.parse_args()
+
+    curriculum_dir: Path = args.curriculum_path
+
+    with open(curriculum_dir / "info.yaml", encoding="utf=8") as curriculum_info_yaml:
+        curriculum_params = yaml.safe_load(curriculum_info_yaml)
+    logger.info("Input curriculum has %d dirs/situations.", curriculum_params["num_dirs"])
+
+    for situation_num in tqdm(
+        range(curriculum_params["num_dirs"]),
+        desc="Situations processed",
+        total=curriculum_params["num_dirs"],
+    ):
+        feature_path = curriculum_dir / f"situation_{situation_num}" / "feature.yaml"
+        with feature_path.open(encoding="utf-8") as feature_yaml_file:
+            features = yaml.safe_load(feature_yaml_file)
+
+        features["objects"] = (
+            [filter_by_largest_box_area(features["objects"])]
+            if len(features["objects"]) > 0
+            else []
+        )
+        features["touching"] = []
+
+        with feature_path.open("w", encoding="utf-8") as feature_out_file:
+            yaml.safe_dump(features, feature_out_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/adam/curriculum/organize_objects.py
+++ b/adam/curriculum/organize_objects.py
@@ -1,0 +1,129 @@
+"""Script to organize a set of image/object pairs as a train/test curriculums"""
+import argparse
+import logging
+from pathlib import Path
+from typing import Tuple, Generator, Dict
+
+import cv2
+import yaml
+
+from adam.ontology.phase3_ontology import PHASE_3_CURRICULUM_OBJECTS
+
+logger = logging.getLogger(__name__)
+
+
+def img_iter(source_img_dir: Path) -> Generator[Tuple[str, Path], None, None]:
+    """Function to load concept name and image as a single iterable."""
+    for object_concept in PHASE_3_CURRICULUM_OBJECTS:
+        concept_path = source_img_dir / object_concept.handle
+
+        if not concept_path.is_dir():
+            logger.warning(
+                "Concept %s not found in given directory", object_concept.handle
+            )
+            continue
+
+        for img_path in sorted(concept_path.glob("*.png")):
+            yield object_concept.handle, img_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Utility script to reorganize object curricula"
+    )
+    parser.add_argument("input_img_dir", type=Path, help="Input set of images.")
+    parser.add_argument(
+        "base_curriculum_dir", type=Path, help="Base directory for curriculum storage."
+    )
+    parser.add_argument(
+        "curriculum_name", type=str, help="The name of the curriculum to create."
+    )
+    parser.add_argument(
+        "--train-num",
+        type=int,
+        default=10,
+        help="The number of samples to put in the training curriculum. The rest of the samples will go the test curriculum.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Enable writing over an existing curriculum directory.",
+    )
+    parser.add_argument(
+        "--image-size",
+        nargs=2,
+        metavar=("img_width", "img_height"),
+        help="The values to resize the give curriculum images to. Must be 16x9 & both divisible by 8.",
+        default=(384, 216),
+        type=int,
+    )
+    args = parser.parse_args()
+
+    source_img_dir: Path = args.input_img_dir
+    train_curriculum_dir: Path = args.base_curriculum_dir / "train" / args.curriculum_name
+    test_curriculum_dir: Path = (
+        args.base_curriculum_dir / "test" / f"{args.curriculum_name}_eval"
+    )
+
+    img_width = args.image_size[0]
+    img_height = args.image_size[1]
+
+    # We assert this to validate that the STEGO API will not crash
+    assert img_width % 16 == 0
+    assert img_height % 8 == 0 and img_height % 9 == 0
+
+    train_curriculum_dir.mkdir(exist_ok=args.overwrite, parents=True)
+    test_curriculum_dir.mkdir(exist_ok=args.overwrite, parents=True)
+
+    train_scene_count = 0
+    test_scene_count = 0
+    img2 = None
+    object_names_to_count: Dict[str, int] = {}
+    for object_name, scene_img in img_iter(source_img_dir):
+        if object_names_to_count.get(object_name, 0) < args.train_num:
+            sit_dir = train_curriculum_dir / f"situation_{train_scene_count}"
+            train_scene_count += 1
+        else:
+            sit_dir = test_curriculum_dir / f"situation_{test_scene_count}"
+            test_scene_count += 1
+        sit_dir.mkdir(parents=True, exist_ok=True)
+
+        img = cv2.imread(str(scene_img))
+        img = cv2.resize(img, (img_width, img_height))
+        try:
+            img2 = cv2.cvtColor(img, cv2.COLOR_RGBA2RGB)
+            logger.debug(f"Image {scene_img} is RGBA")
+        except ValueError:
+            logger.debug(f"Image {scene_img} is RGB")
+            img2 = img
+        finally:
+            cv2.imwrite(str(sit_dir / "rgb_0.png"), img2)
+
+        with (sit_dir / "description.yaml").open("w", encoding="utf-8") as desc_file:
+            yaml.dump({"language": f"a {object_name}"}, desc_file)
+
+        object_names_to_count[object_name] = object_names_to_count.get(object_name, 0) + 1
+
+    with (train_curriculum_dir / "info.yaml").open("w", encoding="utf-8") as info_file:
+        yaml.dump(
+            {"curriculum": args.curriculum_name, "num_dirs": train_scene_count},
+            info_file,
+        )
+
+    with (test_curriculum_dir / "info.yaml").open("w", encoding="utf-8") as info_file:
+        yaml.dump(
+            {"curriculum": f"{args.curriculum_name}_eval", "num_dirs": test_scene_count},
+            info_file,
+        )
+
+    logger.info("Processing complete. Object names to scenes processed:")
+    for object_name, count in object_names_to_count.items():
+        if count <= args.train_num:
+            logger.error(
+                f"Concept {object_name} did not reach the number of training samples requested or has 0 test samples."
+            )
+        logger.info(f"{object_name} - {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/parameters/experiments/p6_isi/m5_isi_rcnn.params
+++ b/parameters/experiments/p6_isi/m5_isi_rcnn.params
@@ -1,0 +1,88 @@
+# For use with adam.experiment.run_pipeline
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: true
+    do_object_segmentation: true
+    copy_segmentations_from_base: false
+    segmentation_model: "rcnn"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    gnn_partition: "ephemeral-lg"
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    # Use the M6 reorganized version of the M5 objects curriculum
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m5_objects"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m5_objects_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m5_isi_rcnn"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m5_isi_rnn_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m5_isi_rcnn_experiment"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p6_isi/m5_isi_rcnn.params
+++ b/parameters/experiments/p6_isi/m5_isi_rcnn.params
@@ -12,6 +12,7 @@ pipeline:
     strokes_use_refined_colors: false
     merge_small_strokes: false
     extract_strokes: true
+    filter_train_curriculum: true
     train_gnn: true
     gnn_decode: true
     gnn_partition: "ephemeral-lg"

--- a/parameters/experiments/p6_isi/m5_isi_stego.params
+++ b/parameters/experiments/p6_isi/m5_isi_stego.params
@@ -12,6 +12,7 @@ pipeline:
     strokes_use_refined_colors: false
     merge_small_strokes: false
     extract_strokes: true
+    filter_train_curriculum: true
     train_gnn: true
     gnn_decode: true
     gnn_partition: "ephemeral-lg"

--- a/parameters/experiments/p6_isi/m5_isi_stego.params
+++ b/parameters/experiments/p6_isi/m5_isi_stego.params
@@ -1,0 +1,88 @@
+# For use with adam.experiment.run_pipeline
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: true
+    do_object_segmentation: true
+    copy_segmentations_from_base: false
+    segmentation_model: "stego"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    gnn_partition: "ephemeral-lg"
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    # Use the M6 reorganized version of the M5 objects curriculum
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m5_objects"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m5_objects_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m5_isi_stego"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m5_isi_stego_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m5_isi_rcnn_experiment"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p6_isi/m6_isi_rcnn.params
+++ b/parameters/experiments/p6_isi/m6_isi_rcnn.params
@@ -1,0 +1,88 @@
+# For use with adam.experiment.run_pipeline
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: true
+    do_object_segmentation: true
+    copy_segmentations_from_base: false
+    segmentation_model: "rcnn"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    gnn_partition: "ephemeral-lg"
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    # Use the M6 reorganized version of the M5 objects curriculum
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m6_isi_objects"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m6_isi_objects_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_isi_rcnn"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_isi_rnn_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_isi_rcnn_experiment"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p6_isi/m6_isi_rcnn.params
+++ b/parameters/experiments/p6_isi/m6_isi_rcnn.params
@@ -12,6 +12,7 @@ pipeline:
     strokes_use_refined_colors: false
     merge_small_strokes: false
     extract_strokes: true
+    filter_train_curriculum: true
     train_gnn: true
     gnn_decode: true
     gnn_partition: "ephemeral-lg"

--- a/parameters/experiments/p6_isi/m6_isi_stego.params
+++ b/parameters/experiments/p6_isi/m6_isi_stego.params
@@ -1,0 +1,88 @@
+# For use with adam.experiment.run_pipeline
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: true
+    do_object_segmentation: true
+    copy_segmentations_from_base: false
+    segmentation_model: "stego"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    gnn_partition: "ephemeral-lg"
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    # Use the M6 reorganized version of the M5 objects curriculum
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m6_isi_objects"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m6_isi_objects_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_isi_stego"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_isi_stego_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_isi_stego_experiment"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p6_isi/m6_isi_stego.params
+++ b/parameters/experiments/p6_isi/m6_isi_stego.params
@@ -12,6 +12,7 @@ pipeline:
     strokes_use_refined_colors: false
     merge_small_strokes: false
     extract_strokes: true
+    filter_train_curriculum: true
     train_gnn: true
     gnn_decode: true
     gnn_partition: "ephemeral-lg"

--- a/parameters/experiments/p6_isi/m6_isi_test.params
+++ b/parameters/experiments/p6_isi/m6_isi_test.params
@@ -1,0 +1,86 @@
+# For use with adam.experiment.run_pipeline
+_includes:
+   - "../../root.params"
+
+pipeline:
+    use_sbatch: true
+    do_object_segmentation: true
+    copy_segmentations_from_base: false
+    segmentation_model: "stego"
+    segment_colors: false
+    refine_colors: false
+    strokes_use_refined_colors: false
+    merge_small_strokes: false
+    extract_strokes: true
+    train_gnn: true
+    gnn_decode: true
+    gnn_partition: "ephemeral-lg"
+    submission_details_path: "%experiment_group_dir%/submission_details.log"
+    job_logs_path: "%experiment_group_dir%/job_logs"
+    stroke_model_path: "%experiment_group_dir%/gnn/pytorch_model.bin"
+    stroke_python_bin_dir: "%stroke_python_root%/bin"
+    adam_params_cache_file: "%experiment_group_dir%/adam_params.params"
+    # Use the M6 reorganized version of the M5 objects curriculum
+    base_train_curriculum_path: "%adam_experiment_root%/curriculum/train/m6_isi_objects"
+    base_test_curriculum_path: "%adam_experiment_root%/curriculum/test/m6_isi_objects_eval"
+    train_curriculum_path: "%adam_experiment_root%/curriculum/train/%train_curriculum.curriculum%"
+    test_curriculum_path: "%adam_experiment_root%/curriculum/test/%test_curriculum.curriculum%"
+
+# Learner Configuration
+learner: simulated-integrated-learner-params
+object_learner:
+    learner_type: "subset"
+    ontology: "phase3"
+    min_continuous_feature_match_score: 0.05
+attribute_learner:
+    learner_type: "none"
+relation_learner:
+    learner_type: "none"
+action_learner:
+    learner_type: "none"
+plural_learner:
+    learner_type: "none"
+affordance_learner:
+    learner_type: "none"
+include_functional_learner: false
+include_generics_learner: false
+include_mapping_affordance_learner: false
+suppress_error: false
+
+# Curriculum Configuration
+curriculum: "phase3"
+train_curriculum:
+    curriculum_type: "training"
+    curriculum: "m6_isi_base_experiment"
+    color_is_rgb: True
+test_curriculum:
+    curriculum_type: "testing"
+    curriculum: "m6_isi_base_experiment_eval"
+    color_is_rgb: True
+
+# Experiment Configuration
+experiment: "m6_isi_base_experiment"
+experiment_group_dir: '%adam_experiment_root%/learners/%learner%/experiments/%train_curriculum.curriculum%/'
+log_learner_state: true
+experiment_type: simulated
+
+# Hypothesis Logging
+hypothesis_log_dir: "%experiment_group_dir%/hypotheses"
+log_hypothesis_every_n_steps: 250
+
+# Debug Configuration
+debug_log_directory: "%experiment_group_dir%/graphs"
+debug_perception_log_dir: "%experiment_group_dir%/perception_graphs"
+
+# Observer Params
+post_observer:
+    experiment_output_path: "%experiment_group_dir%"
+    copy_curriculum: true
+    file_name: "post_decode"
+
+test_observer:
+    experiment_output_path: "%post_observer.experiment_output_path%/test_curriculums/%test_curriculum.curriculum%/"
+    copy_curriculum: true
+    file_name: "post_decode"
+    calculate_accuracy_by_language: true
+    calculate_overall_accuracy: true

--- a/parameters/experiments/p6_isi/m6_isi_test.params
+++ b/parameters/experiments/p6_isi/m6_isi_test.params
@@ -12,6 +12,7 @@ pipeline:
     strokes_use_refined_colors: false
     merge_small_strokes: false
     extract_strokes: true
+    filter_train_curriculum: true
     train_gnn: true
     gnn_decode: true
     gnn_partition: "ephemeral-lg"

--- a/slurm/filter_curriculum.sh
+++ b/slurm/filter_curriculum.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ADAM_FilterTrain
+#SBATCH --account=borrowed
+#SBATCH --partition=ephemeral
+#SBATCH --qos=ephemeral
+#SBATCH --time=1:00:00 # Number of hours required per node, max 24 on SAGA
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16g
+#SBATCH --nodes=1
+#SBATCH --mail-type=FAIL,SUCCESS
+#SBATCH --output=R-%x.%j.out
+set -u
+
+if [[ "$#" -ne 1 ]] || [[ "$1" = "--help" ]] ; then
+  printf '%s\n' "usage: $0 curriculum_path"
+  exit 1
+else
+  curriculum_path=$1
+  shift 1
+fi
+
+# Because we force there to be only 1 args and then shift by 1, "$@" should expand to nothing.
+# It's included as future-proofing in case we add/allow more args.
+PYTHONPATH=. python adam/curriculum/filter_curriculum.py "$curriculum_path" "$@"


### PR DESCRIPTION
This PR adds a script to transform a directory of images into an ADAM curriculum along a given train/test split. 
Additionally this adds the params for the M6 Stego/RCNN experiments along with other bug fixes to support.