### PR TITLE
Fix crash when learner hypothesis and perception have continuous nodes

### DIFF
--- a/adam/learner/attributes.py
+++ b/adam/learner/attributes.py
@@ -182,7 +182,7 @@ class SubsetAttributeLearner(
             match_mode=MatchMode.NON_OBJECT,
             allowed_matches=immutablesetmultidict(
                 [
-                    (node2, node1)
+                    (node1, node2)
                     for previous_slot, node1 in previous_pattern_hypothesis.template_variable_to_pattern_node.items()
                     for new_slot, node2 in current_pattern_hypothesis.template_variable_to_pattern_node.items()
                     if previous_slot == new_slot

--- a/adam/learner/objects.py
+++ b/adam/learner/objects.py
@@ -238,7 +238,7 @@ class SubsetObjectLearner(AbstractObjectTemplateLearner, AbstractTemplateSubsetL
             match_mode=MatchMode.OBJECT,
             allowed_matches=immutablesetmultidict(
                 [
-                    (node2, node1)
+                    (node1, node2)
                     for previous_slot, node1 in previous_pattern_hypothesis.template_variable_to_pattern_node.items()
                     for new_slot, node2 in current_pattern_hypothesis.template_variable_to_pattern_node.items()
                     if previous_slot == new_slot

--- a/adam/learner/perception_graph_template.py
+++ b/adam/learner/perception_graph_template.py
@@ -1,6 +1,6 @@
 from logging import INFO
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, Optional, Union, Iterable
+from typing import Any, Callable, List, Mapping, Optional, Union, Iterable, cast
 
 from attr import attrib, attrs
 from attr.validators import deep_mapping, instance_of
@@ -205,7 +205,7 @@ class PerceptionGraphTemplate:
             slots_preserved = True
             for (_, object_wildcard) in template_variable_to_pattern_node.items():
                 # we return none here since this means that the given template cannot be learned from since one of the slots has been pruned away
-                if object_wildcard not in intersected_pattern_match.matched_pattern:
+                if object_wildcard not in intersected_pattern_match.matched_sub_graph:
                     slots_preserved = False
                     break
 
@@ -213,7 +213,10 @@ class PerceptionGraphTemplate:
                 PerceptionGraphTemplateIntersectionResult(
                     intersected_pattern_match,
                     PerceptionGraphTemplate(
-                        graph_pattern=intersected_pattern_match.matched_pattern,
+                        graph_pattern=cast(
+                            PerceptionGraphPattern,
+                            intersected_pattern_match.matched_sub_graph,
+                        ),
                         template_variable_to_pattern_node=template_variable_to_pattern_node,
                     ),
                 )

--- a/adam/learner/plurals.py
+++ b/adam/learner/plurals.py
@@ -159,7 +159,7 @@ class SubsetPluralLearner(AbstractTemplateSubsetLearner, AbstractPluralTemplateL
             match_mode=MatchMode.NON_OBJECT,
             allowed_matches=immutablesetmultidict(
                 [
-                    (node2, node1)
+                    (node1, node2)
                     for previous_slot, node1 in previous_pattern_hypothesis.template_variable_to_pattern_node.items()
                     for new_slot, node2 in current_pattern_hypothesis.template_variable_to_pattern_node.items()
                     if previous_slot == new_slot

--- a/adam/learner/relations.py
+++ b/adam/learner/relations.py
@@ -149,7 +149,7 @@ class SubsetRelationLearner(
             match_mode=MatchMode.NON_OBJECT,
             allowed_matches=immutablesetmultidict(
                 [
-                    (node2, node1)
+                    (node1, node2)
                     for previous_slot, node1 in previous_pattern_hypothesis.template_variable_to_pattern_node.items()
                     for new_slot, node2 in current_pattern_hypothesis.template_variable_to_pattern_node.items()
                     if previous_slot == new_slot

--- a/adam/learner/verbs.py
+++ b/adam/learner/verbs.py
@@ -152,7 +152,7 @@ class SubsetVerbLearner(AbstractTemplateSubsetLearner, AbstractVerbTemplateLearn
             match_mode=MatchMode.NON_OBJECT,
             allowed_matches=immutablesetmultidict(
                 [
-                    (node2, node1)
+                    (node1, node2)
                     for previous_slot, node1 in previous_pattern_hypothesis.template_variable_to_pattern_node.items()
                     for new_slot, node2 in current_pattern_hypothesis.template_variable_to_pattern_node.items()
                     if previous_slot == new_slot

--- a/adam/perception/perception_graph.py
+++ b/adam/perception/perception_graph.py
@@ -1215,8 +1215,8 @@ class PerceptionGraphPattern(PerceptionGraphProtocol, Sized, Iterable["NodePredi
         ] = None,
     ) -> Optional["PerceptionGraphPatternMatch"]:
         matcher = PatternMatching(
-            pattern=graph_pattern,
-            graph_to_match_against=self,
+            pattern=self,
+            graph_to_match_against=graph_pattern,
             debug_callback=debug_callback,
             matching_pattern_against_pattern=True,
             match_mode=match_mode,


### PR DESCRIPTION
The crash happened because we were actually updating the new hypothesis created from the current perception, rather than updating the old hypothesis.